### PR TITLE
Implement SimpleRedirect

### DIFF
--- a/src/main/java/com/k3ntako/HTTPServer/Main.java
+++ b/src/main/java/com/k3ntako/HTTPServer/Main.java
@@ -2,6 +2,7 @@ package com.k3ntako.HTTPServer;
 
 import com.k3ntako.HTTPServer.routes.SimpleGet;
 import com.k3ntako.HTTPServer.routes.SimpleGetWithBody;
+import com.k3ntako.HTTPServer.routes.SimpleRedirect;
 import com.k3ntako.HTTPServer.wrappers.ServerSocketWrapper;
 
 import java.util.HashMap;
@@ -15,6 +16,7 @@ public class Main {
     var routes = new HashMap<String, RouteInterface>();
     routes.put("/simple_get", new SimpleGet());
     routes.put("/simple_get_with_body", new SimpleGetWithBody());
+    routes.put("/redirect", new SimpleRedirect());
     var router = new Router(routes);
 
     var app = new Server(serverIO, requestHandler, serverSocket, router);

--- a/src/main/java/com/k3ntako/HTTPServer/Response.java
+++ b/src/main/java/com/k3ntako/HTTPServer/Response.java
@@ -2,15 +2,18 @@ package com.k3ntako.HTTPServer;
 
 
 import java.util.HashMap;
+import java.util.Map;
 
 public class Response {
   private String body = "";
   private int status = 200;
+  private HashMap<String, String> additionalHeaders = new HashMap<>();
 
   public Response() {
     this.statuses = new HashMap<>();
 
     this.statuses.put(200, "OK");
+    this.statuses.put(301, "Moved Permanently");
     this.statuses.put(404, "Not Found");
   }
 
@@ -24,16 +27,39 @@ public class Response {
     var statusMessage = statuses.get(status);
 
     var header = "HTTP/1.1 " + status + " " + statusMessage + "\r\n";
-    header = header + "Content-Length: " + contentLength + "\r\n\r\n";
+
+    var additionalHeaders = stringifyAdditionHeaders();
+    header += additionalHeaders;
+
+    header += "Content-Length: " + contentLength + "\r\n\r\n";
 
     return header;
   }
 
-  public void setBody(String body){
+  public void setBody(String body) {
     this.body = body;
   }
 
-  public void setStatus(int status){
+  public void setStatus(int status) {
     this.status = status;
+  }
+
+  public void addHeader(String key, String value) {
+    additionalHeaders.put(key, value);
+  }
+
+  private String stringifyAdditionHeaders() {
+    var stringBuilder = new StringBuilder();
+    for (Map.Entry<String, String> entry : additionalHeaders.entrySet()) {
+      String key = entry.getKey();
+      String value = entry.getValue();
+
+      stringBuilder.append(key);
+      stringBuilder.append(": ");
+      stringBuilder.append(value);
+      stringBuilder.append("\r\n");
+    }
+
+    return stringBuilder.toString();
   }
 }

--- a/src/main/java/com/k3ntako/HTTPServer/routes/SimpleRedirect.java
+++ b/src/main/java/com/k3ntako/HTTPServer/routes/SimpleRedirect.java
@@ -1,0 +1,15 @@
+package com.k3ntako.HTTPServer.routes;
+
+import com.k3ntako.HTTPServer.RequestInterface;
+import com.k3ntako.HTTPServer.Response;
+import com.k3ntako.HTTPServer.RouteInterface;
+
+public class SimpleRedirect implements RouteInterface {
+  @Override
+  public Response getResponse(RequestInterface request) {
+    var response = new Response();
+    response.setStatus(301);
+    response.addHeader("Location", "http://127.0.0.1:5000/simple_get");
+    return response;
+  }
+}

--- a/src/test/java/com/k3ntako/HTTPServer/ResponseTest.java
+++ b/src/test/java/com/k3ntako/HTTPServer/ResponseTest.java
@@ -10,10 +10,6 @@ class ResponseTest {
 
   @Test
   void createEmptyResponse() {
-    HashMap<String, String> headers = new HashMap<>();
-    headers.put("Content-Length", "17");
-    headers.put("Content-Type", "text/html; charset=UTF-8");
-
     var response = new Response();
 
     var headerStr = response.createResponse();
@@ -25,10 +21,6 @@ class ResponseTest {
 
   @Test
   void createResponseWithBody() {
-    HashMap<String, String> headers = new HashMap<>();
-    headers.put("Content-Length", "17");
-    headers.put("Content-Type", "text/html; charset=UTF-8");
-
     var response = new Response();
     response.setBody("This\nis\nthe\nresponse\nbody!!");
 
@@ -42,15 +34,26 @@ class ResponseTest {
 
   @Test
   void setStatus() {
-    HashMap<String, String> headers = new HashMap<>();
-    headers.put("Content-Length", "17");
-    headers.put("Content-Type", "text/html; charset=UTF-8");
-
     var response = new Response();
     response.setStatus(404);
 
     var headerStr = response.createResponse();
     var expected = "HTTP/1.1 404 Not Found\r\n" +
+            "Content-Length: 0\r\n\r\n";
+
+    assertEquals(expected, headerStr);
+  }
+
+  @Test
+  void addHeader() {
+    var response = new Response();
+    response.setStatus(301);
+    response.addHeader("Location", "/simple_get");
+
+    var headerStr = response.createResponse();
+
+    var expected = "HTTP/1.1 301 Moved Permanently\r\n" +
+            "Location: /simple_get\r\n" +
             "Content-Length: 0\r\n\r\n";
 
     assertEquals(expected, headerStr);

--- a/src/test/java/com/k3ntako/HTTPServer/routes/SimpleGetWithBodyTest.java
+++ b/src/test/java/com/k3ntako/HTTPServer/routes/SimpleGetWithBodyTest.java
@@ -10,7 +10,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class SimpleGetWithBodyTest {
 
   @Test
-  void getResonse() {
+  void getResponse() {
     var request = new RequestMock("GET", "/simple_get_with_body", "HTTP/1.1", new HashMap<>(), "");
 
     var simpleGetWithBody = new SimpleGetWithBody();

--- a/src/test/java/com/k3ntako/HTTPServer/routes/SimpleRedirectTest.java
+++ b/src/test/java/com/k3ntako/HTTPServer/routes/SimpleRedirectTest.java
@@ -1,0 +1,25 @@
+package com.k3ntako.HTTPServer.routes;
+
+import com.k3ntako.HTTPServer.mocks.RequestMock;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SimpleRedirectTest {
+
+  @Test
+  void getResponse() {
+    var request = new RequestMock("GET", "/simple_redirect", "HTTP/1.1", new HashMap<>(), "");
+
+    var simpleRedirect = new SimpleRedirect();
+    var response = simpleRedirect.getResponse(request);
+
+    var responseStr = response.createResponse();
+    var expectedResponse = "HTTP/1.1 301 Moved Permanently\r\n" +
+            "Location: http://127.0.0.1:5000/simple_get\r\n" +
+            "Content-Length: 0\r\n\r\n";
+    assertEquals(expectedResponse, responseStr);
+  }
+}


### PR DESCRIPTION
Implemented to pass HTTP Server Spec for Simple Redirect
https://github.com/8thlight/http_server_spec/blob/master/features/steps/01_getting_started/simple_redirect.rb

It will return a `301` and set the redirect location to `http://127.0.0.1:5000/simple_get`.