### PR TITLE
Handle error

### DIFF
--- a/src/main/java/com/k3ntako/HTTPServer/ErrorHandler.java
+++ b/src/main/java/com/k3ntako/HTTPServer/ErrorHandler.java
@@ -1,0 +1,26 @@
+package com.k3ntako.HTTPServer;
+
+public class ErrorHandler implements ErrorHandlerInterface {
+  @Override
+  public Response handleError(HTTPError e){
+    return generateErrorResponse(e.getStatus(), e);
+  }
+
+  @Override
+  public Response handleError(Exception e){
+    return generateErrorResponse(500, e);
+  }
+
+  private Response generateErrorResponse(int status, Exception exception) {
+    var response = new Response();
+    response.setStatus(status);
+
+    var message = exception.getMessage();
+    if(message == null){
+      message = exception.getClass().getName();
+    }
+    response.setBody(message);
+
+    return response;
+  }
+}

--- a/src/main/java/com/k3ntako/HTTPServer/ErrorHandlerInterface.java
+++ b/src/main/java/com/k3ntako/HTTPServer/ErrorHandlerInterface.java
@@ -1,0 +1,7 @@
+package com.k3ntako.HTTPServer;
+
+public interface ErrorHandlerInterface {
+  Response handleError(HTTPError e);
+
+  Response handleError(Exception e);
+}

--- a/src/main/java/com/k3ntako/HTTPServer/HTTPError.java
+++ b/src/main/java/com/k3ntako/HTTPServer/HTTPError.java
@@ -1,0 +1,14 @@
+package com.k3ntako.HTTPServer;
+
+public class HTTPError extends Exception {
+  private int status;
+
+  public HTTPError(int status, String message) {
+    super(message);
+    this.status = status;
+  }
+
+  public int getStatus() {
+    return this.status;
+  }
+}

--- a/src/main/java/com/k3ntako/HTTPServer/Main.java
+++ b/src/main/java/com/k3ntako/HTTPServer/Main.java
@@ -5,14 +5,14 @@ import com.k3ntako.HTTPServer.wrappers.ServerSocketWrapper;
 public class Main {
   public static void main(String[] args) throws Exception {
     var serverIO = new ServerServerIO();
-    var requestGenerator = new RequestGenerator();
     var serverSocket = new ServerSocketWrapper(5000);
 
     var routeRegistrar = new RouteRegistrar(new RouteRegistry(), new FileIO());
     var routeRegistry = routeRegistrar.registerRoutes();
     var router = new Router(routeRegistry);
+    var requestHandler = new RequestHandler(router, new RequestGenerator());
 
-    var app = new Server(serverIO, requestGenerator, serverSocket, router);
+    var app = new Server(serverIO, requestHandler, serverSocket, router);
 
     while (true) {
       app.run();

--- a/src/main/java/com/k3ntako/HTTPServer/Main.java
+++ b/src/main/java/com/k3ntako/HTTPServer/Main.java
@@ -2,19 +2,17 @@ package com.k3ntako.HTTPServer;
 
 import com.k3ntako.HTTPServer.wrappers.ServerSocketWrapper;
 
-import java.io.IOException;
-
 public class Main {
   public static void main(String[] args) throws Exception {
     var serverIO = new ServerServerIO();
-    var requestHandler = new RequestHandler();
+    var requestGenerator = new RequestGenerator();
     var serverSocket = new ServerSocketWrapper(5000);
 
     var routeRegistrar = new RouteRegistrar(new RouteRegistry(), new FileIO());
     var routeRegistry = routeRegistrar.registerRoutes();
     var router = new Router(routeRegistry);
 
-    var app = new Server(serverIO, requestHandler, serverSocket, router);
+    var app = new Server(serverIO, requestGenerator, serverSocket, router);
 
     while (true) {
       app.run();

--- a/src/main/java/com/k3ntako/HTTPServer/Request.java
+++ b/src/main/java/com/k3ntako/HTTPServer/Request.java
@@ -17,20 +17,16 @@ public class Request implements RequestInterface {
     this.headers = new HashMap<>();
   }
 
-  public void parseRequest() {
-    try {
-      this.parseHeader();
+  public void parseRequest() throws IOException {
+    this.parseHeader();
 
-      var contentLength = 0;
-      if (this.headers.containsKey("Content-Length")) {
-        contentLength = Integer.parseInt(this.headers.get("Content-Length"));
-      }
+    var contentLength = 0;
+    if (this.headers.containsKey("Content-Length")) {
+      contentLength = Integer.parseInt(this.headers.get("Content-Length"));
+    }
 
-      if (contentLength > 0) {
-        this.parseBody(contentLength);
-      }
-    } catch (IOException e) {
-      e.printStackTrace();
+    if (contentLength > 0) {
+      this.parseBody(contentLength);
     }
   }
 
@@ -73,20 +69,16 @@ public class Request implements RequestInterface {
     }
   }
 
-  private void parseBody(int contentLength) {
-    try {
-      var bodyStr = "";
-      char character;
+  private void parseBody(int contentLength) throws IOException {
+    var bodyStr = "";
+    char character;
 
-      while (bodyStr.length() < contentLength) {
-        character = (serverIO.read());
-        bodyStr = bodyStr.concat(String.valueOf(character));
-      }
-
-      this.body = bodyStr;
-    } catch (IOException e) {
-      e.printStackTrace();
+    while (bodyStr.length() < contentLength) {
+      character = (serverIO.read());
+      bodyStr = bodyStr.concat(String.valueOf(character));
     }
+
+    this.body = bodyStr;
   }
 
   public String getMethod() {

--- a/src/main/java/com/k3ntako/HTTPServer/RequestGenerator.java
+++ b/src/main/java/com/k3ntako/HTTPServer/RequestGenerator.java
@@ -2,9 +2,9 @@ package com.k3ntako.HTTPServer;
 
 import java.io.IOException;
 
-public class RequestHandler implements RequestHandlerInterface {
+public class RequestGenerator implements RequestGeneratorInterface {
   @Override
-  public Request handleRequest(ServerIOInterface serverIO) throws IOException {
+  public Request generateRequest(ServerIOInterface serverIO) throws IOException {
     var request = new Request(serverIO);
     request.parseRequest();
     return request;

--- a/src/main/java/com/k3ntako/HTTPServer/RequestGeneratorInterface.java
+++ b/src/main/java/com/k3ntako/HTTPServer/RequestGeneratorInterface.java
@@ -1,0 +1,7 @@
+package com.k3ntako.HTTPServer;
+
+import java.io.IOException;
+
+public interface RequestGeneratorInterface {
+  RequestInterface generateRequest(ServerIOInterface serverIO) throws IOException, HTTPError;
+}

--- a/src/main/java/com/k3ntako/HTTPServer/RequestHandler.java
+++ b/src/main/java/com/k3ntako/HTTPServer/RequestHandler.java
@@ -1,0 +1,35 @@
+package com.k3ntako.HTTPServer;
+
+public class RequestHandler {
+  private Router router;
+  private RequestGeneratorInterface requestGenerator;
+  private ErrorHandlerInterface errorHandler;
+
+  public RequestHandler(Router router, RequestGeneratorInterface requestGenerator) {
+    this.router = router;
+    this.requestGenerator = requestGenerator;
+  }
+
+  public String handleRequest(ServerIOInterface serverIO) throws Exception {
+    try {
+      var request = this.requestGenerator.generateRequest(serverIO);
+      var response = this.router.routeRequest(request);
+      return response.createResponse();
+    } catch (Exception e) {
+      return this.handleError(e);
+    }
+  }
+
+  public void useErrorHandler(ErrorHandlerInterface errorHandler) {
+    this.errorHandler = errorHandler;
+  }
+
+  private String handleError(Exception e) throws Exception {
+    if(this.errorHandler == null){
+      throw e;
+    }
+
+    var response = this.errorHandler.handleError(e);
+    return response.createResponse();
+  }
+}

--- a/src/main/java/com/k3ntako/HTTPServer/RequestHandler.java
+++ b/src/main/java/com/k3ntako/HTTPServer/RequestHandler.java
@@ -1,8 +1,10 @@
 package com.k3ntako.HTTPServer;
 
+import java.io.IOException;
+
 public class RequestHandler implements RequestHandlerInterface {
   @Override
-  public Request handleRequest(ServerIOInterface serverIO){
+  public Request handleRequest(ServerIOInterface serverIO) throws IOException {
     var request = new Request(serverIO);
     request.parseRequest();
     return request;

--- a/src/main/java/com/k3ntako/HTTPServer/RequestHandlerInterface.java
+++ b/src/main/java/com/k3ntako/HTTPServer/RequestHandlerInterface.java
@@ -1,5 +1,7 @@
 package com.k3ntako.HTTPServer;
 
+import java.io.IOException;
+
 public interface RequestHandlerInterface {
-  RequestInterface handleRequest(ServerIOInterface serverIO);
+  RequestInterface handleRequest(ServerIOInterface serverIO) throws IOException, HTTPError;
 }

--- a/src/main/java/com/k3ntako/HTTPServer/RequestHandlerInterface.java
+++ b/src/main/java/com/k3ntako/HTTPServer/RequestHandlerInterface.java
@@ -1,7 +1,0 @@
-package com.k3ntako.HTTPServer;
-
-import java.io.IOException;
-
-public interface RequestHandlerInterface {
-  RequestInterface handleRequest(ServerIOInterface serverIO) throws IOException, HTTPError;
-}

--- a/src/main/java/com/k3ntako/HTTPServer/RequestInterface.java
+++ b/src/main/java/com/k3ntako/HTTPServer/RequestInterface.java
@@ -1,9 +1,10 @@
 package com.k3ntako.HTTPServer;
 
+import java.io.IOException;
 import java.util.HashMap;
 
 public interface RequestInterface {
-  void parseRequest();
+  void parseRequest() throws IOException;
 
   String getMethod();
 

--- a/src/main/java/com/k3ntako/HTTPServer/Server.java
+++ b/src/main/java/com/k3ntako/HTTPServer/Server.java
@@ -7,18 +7,18 @@ import java.net.Socket;
 
 public class Server {
   private ServerIOInterface serverIO;
-  private RequestHandlerInterface requestHandler;
+  private RequestGeneratorInterface requestGenerator;
   private ServerSocketWrapperInterface serverSocket;
   private Router router;
 
   public Server(
       ServerIOInterface serverIO,
-      RequestHandlerInterface requestHandler,
+      RequestGeneratorInterface requestGenerator,
       ServerSocketWrapperInterface serverSocket,
       Router router
   ) {
     this.serverIO = serverIO;
-    this.requestHandler = requestHandler;
+    this.requestGenerator = requestGenerator;
     this.serverSocket = serverSocket;
     this.router = router;
   }
@@ -30,7 +30,7 @@ public class Server {
     try {
       serverIO.init(clientSocket);
 
-      var request = this.requestHandler.handleRequest(serverIO);
+      var request = this.requestGenerator.generateRequest(serverIO);
       var response = this.router.routeRequest(request);
       responseStr = response.createResponse();
     } catch (HTTPError e) {

--- a/src/main/java/com/k3ntako/HTTPServer/Server.java
+++ b/src/main/java/com/k3ntako/HTTPServer/Server.java
@@ -34,9 +34,11 @@ public class Server {
       var response = this.router.routeRequest(request);
       responseStr = response.createResponse();
     } catch (HTTPError e) {
+      e.printStackTrace();
       var response = generateErrorResponse(e.getStatus(), e);
       responseStr = response.createResponse();
     } catch (Exception e) {
+      e.printStackTrace();
       var response = generateErrorResponse(500, e);
       responseStr = response.createResponse();
     } finally {

--- a/src/main/java/com/k3ntako/HTTPServer/Server.java
+++ b/src/main/java/com/k3ntako/HTTPServer/Server.java
@@ -7,57 +7,31 @@ import java.net.Socket;
 
 public class Server {
   private ServerIOInterface serverIO;
-  private RequestGeneratorInterface requestGenerator;
+  private RequestHandler requestHandler;
   private ServerSocketWrapperInterface serverSocket;
   private Router router;
 
   public Server(
       ServerIOInterface serverIO,
-      RequestGeneratorInterface requestGenerator,
+      RequestHandler requestHandler,
       ServerSocketWrapperInterface serverSocket,
       Router router
   ) {
     this.serverIO = serverIO;
-    this.requestGenerator = requestGenerator;
+    this.requestHandler = requestHandler;
     this.serverSocket = serverSocket;
     this.router = router;
   }
 
-  public void run() throws IOException {
+  public void run() throws Exception {
     var clientSocket = serverSocket.accept();
-    String responseStr = "";
 
-    try {
-      serverIO.init(clientSocket);
+    serverIO.init(clientSocket);
 
-      var request = this.requestGenerator.generateRequest(serverIO);
-      var response = this.router.routeRequest(request);
-      responseStr = response.createResponse();
-    } catch (HTTPError e) {
-      e.printStackTrace();
-      var response = generateErrorResponse(e.getStatus(), e);
-      responseStr = response.createResponse();
-    } catch (Exception e) {
-      e.printStackTrace();
-      var response = generateErrorResponse(500, e);
-      responseStr = response.createResponse();
-    } finally {
-      serverIO.sendData(responseStr);
-      this.close(clientSocket);
-    }
-  }
+    var responseStr = requestHandler.handleRequest(serverIO);
 
-  private Response generateErrorResponse(int status, Exception exception) {
-    var response = new Response();
-    response.setStatus(status);
-
-    var message = exception.getMessage();
-    if(message == null){
-      message = exception.getClass().getName();
-    }
-    response.setBody(message);
-
-    return response;
+    serverIO.sendData(responseStr);
+    this.close(clientSocket);
   }
 
   private void close(Socket clientSocket) throws IOException {

--- a/src/main/java/com/k3ntako/HTTPServer/ServerIOInterface.java
+++ b/src/main/java/com/k3ntako/HTTPServer/ServerIOInterface.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.net.Socket;
 
 public interface ServerIOInterface {
-  void init(Socket clientSocket);
+  void init(Socket clientSocket) throws IOException;
   String readLine() throws IOException;
   char read() throws IOException;
   void sendData(String data);

--- a/src/main/java/com/k3ntako/HTTPServer/ServerServerIO.java
+++ b/src/main/java/com/k3ntako/HTTPServer/ServerServerIO.java
@@ -10,16 +10,12 @@ public class ServerServerIO implements ServerIOInterface {
   private BufferedReader bufferedReader;
   private PrintWriterWrapperInterface printWriter;
 
-  public void init(Socket clientSocket) {
-    try {
-      var inputStreamReader = new InputStreamReader(clientSocket.getInputStream());
-      bufferedReader = new BufferedReader(inputStreamReader);
+  public void init(Socket clientSocket) throws IOException {
+    var inputStreamReader = new InputStreamReader(clientSocket.getInputStream());
+    bufferedReader = new BufferedReader(inputStreamReader);
 
-      var outputStream = clientSocket.getOutputStream();
-      printWriter = new PrintWriterWrapper(outputStream, true);
-    } catch (IOException e) {
-      e.printStackTrace();
-    }
+    var outputStream = clientSocket.getOutputStream();
+    printWriter = new PrintWriterWrapper(outputStream, true);
   }
 
   public String readLine() throws IOException {

--- a/src/main/java/com/k3ntako/HTTPServer/wrappers/PrintWriterWrapper.java
+++ b/src/main/java/com/k3ntako/HTTPServer/wrappers/PrintWriterWrapper.java
@@ -16,10 +16,6 @@ public class PrintWriterWrapper implements PrintWriterWrapperInterface {
   }
 
   public void close() {
-    try {
-      printerWriter.close();
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
+    printerWriter.close();
   }
 }

--- a/src/main/java/com/k3ntako/HTTPServer/wrappers/ServerSocketWrapper.java
+++ b/src/main/java/com/k3ntako/HTTPServer/wrappers/ServerSocketWrapper.java
@@ -7,29 +7,16 @@ import java.net.Socket;
 public class ServerSocketWrapper implements ServerSocketWrapperInterface {
   private ServerSocket serverSocket;
 
-  public ServerSocketWrapper(int port) {
-    try {
-      serverSocket = new ServerSocket(port);
-    } catch (IOException e) {
-      e.printStackTrace();
-    }
+  public ServerSocketWrapper(int port) throws IOException {
+    serverSocket = new ServerSocket(port);
   }
 
-  public Socket accept() {
-    try {
-      return serverSocket.accept();
-    } catch (IOException e) {
-      e.printStackTrace();
-      return null;
-    }
+  public Socket accept() throws IOException {
+    return serverSocket.accept();
   }
 
-  public void close() {
-    try {
-      serverSocket.close();
-    } catch (IOException e) {
-      e.printStackTrace();
-    }
+  public void close() throws IOException {
+    serverSocket.close();
   }
 
   public int port() {

--- a/src/main/java/com/k3ntako/HTTPServer/wrappers/ServerSocketWrapperInterface.java
+++ b/src/main/java/com/k3ntako/HTTPServer/wrappers/ServerSocketWrapperInterface.java
@@ -1,8 +1,9 @@
 package com.k3ntako.HTTPServer.wrappers;
 
+import java.io.IOException;
 import java.net.Socket;
 
 public interface ServerSocketWrapperInterface {
-  Socket accept();
-  void close();
+  Socket accept() throws IOException;
+  void close() throws IOException;
 }

--- a/src/test/java/com/k3ntako/HTTPServer/ErrorHandlerTest.java
+++ b/src/test/java/com/k3ntako/HTTPServer/ErrorHandlerTest.java
@@ -1,0 +1,38 @@
+package com.k3ntako.HTTPServer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ErrorHandlerTest {
+
+  @Test
+  void handleHTTPError() {
+    var httpError = new HTTPError(404, "File was not found");
+    var errorHandler = new ErrorHandler();
+
+    var response = errorHandler.handleError(httpError);
+    var responseStr = response.createResponse();
+
+    var expectedResponse = "HTTP/1.1 404 Not Found\r\n" +
+        "Content-Length: 18\r\n\r\n" +
+        "File was not found";
+
+    assertEquals(expectedResponse, responseStr);
+  }
+
+  @Test
+  void handleServerError() {
+    var error = new Exception("Something went wrong");
+    var errorHandler = new ErrorHandler();
+
+    var response = errorHandler.handleError(error);
+    var responseStr = response.createResponse();
+
+    var expectedResponse = "HTTP/1.1 500 Internal Server Error\r\n" +
+        "Content-Length: 20\r\n\r\n" +
+        "Something went wrong";
+
+    assertEquals(expectedResponse, responseStr);
+  }
+}

--- a/src/test/java/com/k3ntako/HTTPServer/HTTPErrorTest.java
+++ b/src/test/java/com/k3ntako/HTTPServer/HTTPErrorTest.java
@@ -1,0 +1,16 @@
+package com.k3ntako.HTTPServer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class HTTPErrorTest {
+
+  @Test
+  void getErrorInformation() {
+    var error = new HTTPError(500, "This is an error message");
+
+    assertEquals(500, error.getStatus());
+    assertEquals("This is an error message", error.getMessage());
+  }
+}

--- a/src/test/java/com/k3ntako/HTTPServer/RequestHandlerTest.java
+++ b/src/test/java/com/k3ntako/HTTPServer/RequestHandlerTest.java
@@ -1,0 +1,46 @@
+package com.k3ntako.HTTPServer;
+
+import com.k3ntako.HTTPServer.mocks.*;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RequestHandlerTest {
+  @Test
+  void handleRequest() throws Exception {
+    var routeRegistrar = new RouteRegistrar(new RouteRegistry(), new FileIOMock());
+    var routeRegistry = routeRegistrar.registerRoutes();
+
+    var router = new Router(routeRegistry);
+
+    var requestHandler = new RequestHandler(router, new RequestGeneratorMock());
+
+    var expectedResponse = "HTTP/1.1 200 OK\r\n" +
+        "Content-Length: 11\r\n\r\n" +
+        "Hello world";
+
+    var responseStr = requestHandler.handleRequest(new ServerIOMock(""));
+    assertEquals(expectedResponse, responseStr);
+  }
+
+  @Test
+  void useErrorHandler() throws Exception {
+    var routeRegistrar = new RouteRegistrar(new RouteRegistry(), new FileIOMock());
+    var routeRegistry = routeRegistrar.registerRoutes();
+
+    var router = new Router(routeRegistry);
+
+    var requestHandler = new RequestHandler(router, new RequestGeneratorMockThrowsError());
+    requestHandler.useErrorHandler(new ErrorHandler());
+
+    var responseStr = requestHandler.handleRequest(new ServerIOMock(""));
+
+    var expectedResponse = "HTTP/1.1 500 Internal Server Error\r\n" +
+        "Content-Length: 20\r\n\r\n" +
+        "This is a test error";
+
+    assertEquals(expectedResponse, responseStr);
+  }
+}

--- a/src/test/java/com/k3ntako/HTTPServer/RequestTest.java
+++ b/src/test/java/com/k3ntako/HTTPServer/RequestTest.java
@@ -3,6 +3,7 @@ package com.k3ntako.HTTPServer;
 import com.k3ntako.HTTPServer.mocks.ServerIOMock;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.net.Socket;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -10,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class RequestTest {
 
   @Test
-  void parseRequest() {
+  void parseRequest() throws IOException {
     var headerStr = "GET / HTTP/1.1\r\n" +
         "Host: localhost:5000\r\n" +
         "User-Agent: curl/7.64.1\r\n" +
@@ -31,7 +32,7 @@ class RequestTest {
   }
 
   @Test
-  void parseBody() {
+  void parseBody() throws IOException {
     var header = "GET / HTTP/1.1\r\n" +
         "Content-Length: 68\r\n\r\n";
     var bodyStr = "Body line 1: abc\n" +

--- a/src/test/java/com/k3ntako/HTTPServer/ServerTest.java
+++ b/src/test/java/com/k3ntako/HTTPServer/ServerTest.java
@@ -1,12 +1,7 @@
 package com.k3ntako.HTTPServer;
 
-import com.k3ntako.HTTPServer.mocks.FileIOMock;
-import com.k3ntako.HTTPServer.mocks.ServerIOMock;
-import com.k3ntako.HTTPServer.mocks.RequestHandlerMock;
-import com.k3ntako.HTTPServer.mocks.ServerSocketMock;
+import com.k3ntako.HTTPServer.mocks.*;
 import org.junit.jupiter.api.Test;
-
-import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -14,10 +9,10 @@ class ServerTest {
   @Test
   void serverParsesHeader() throws Exception {
     var clientInput = "GET /simple_get_with_body HTTP/1.1\n" +
-        "Host: localhost:5000\n" +
-        "User-Agent: curl/7.64.1\n" +
-        "Accept: */*\n" +
-        "\n\n";
+            "Host: localhost:5000\n" +
+            "User-Agent: curl/7.64.1\n" +
+            "Accept: */*\n" +
+            "\n\n";
 
     var serverIOMock = new ServerIOMock(clientInput);
     var requestHandlerMock = new RequestHandlerMock();
@@ -30,22 +25,22 @@ class ServerTest {
     var app = new Server(serverIOMock, requestHandlerMock, socket, router);
     app.run();
 
-    assertTrue(requestHandlerMock.wasHandleRequestCalled());
+    assertTrue( requestHandlerMock.wasHandleRequestCalled());
   }
 
   @Test
   void serverReturnsInput() throws Exception {
     var clientInput = "GET /simple_get_with_body HTTP/1.1\n" +
-        "Host: localhost:5000\n" +
-        "User-Agent: curl/7.64.1\n" +
-        "Accept: */*\n" +
-        "Content-Length: 68\n" +
-        "\n\n";
+            "Host: localhost:5000\n" +
+            "User-Agent: curl/7.64.1\n" +
+            "Accept: */*\n" +
+            "Content-Length: 68\n" +
+            "\n\n";
 
     var bodyStr = "Body line 1: def\n" +
-        "Body line 2: def\n" +
-        "Body line 3: def\n" +
-        "Body line 4: def";
+            "Body line 2: def\n" +
+            "Body line 3: def\n" +
+            "Body line 4: def";
 
     var serverIO = new ServerIOMock(clientInput + bodyStr);
     var requestHandlerMock = new RequestHandlerMock();
@@ -59,8 +54,40 @@ class ServerTest {
     app.run();
 
     var expected = "HTTP/1.1 200 OK\r\n" +
-        "Content-Length: 11\r\n\r\n" +
-        "Hello world\n";
+            "Content-Length: 11\r\n\r\n" +
+            "Hello world\n";
+
+    assertEquals(expected, serverIO.getSentData());
+  }
+
+  @Test
+  void serverCatchesError() throws Exception {
+    var clientInput = "GET /simple_get_with_body HTTP/1.1\n" +
+        "Host: localhost:5000\n" +
+        "User-Agent: curl/7.64.1\n" +
+        "Accept: */*\n" +
+        "Content-Length: 68\n" +
+        "\n\n";
+
+    var bodyStr = "Body line 1: def\n" +
+        "Body line 2: def\n" +
+        "Body line 3: def\n" +
+        "Body line 4: def";
+
+    var serverIO = new ServerIOMock(clientInput + bodyStr);
+    var requestHandlerMock = new RequestHandlerMockThrowsError();
+    var socket = new ServerSocketMock();
+
+    var routeRegistrar = new RouteRegistrar(new RouteRegistry(), new FileIOMock());
+    var routeRegistry = routeRegistrar.registerRoutes();
+    var router = new Router(routeRegistry);
+
+    var app = new Server(serverIO, requestHandlerMock, socket, router);
+    app.run();
+
+    var expected = "HTTP/1.1 500 Internal Server Error\r\n" +
+        "Content-Length: 20\r\n\r\n" +
+        "This is a test error\n";
 
     assertEquals(expected, serverIO.getSentData());
   }

--- a/src/test/java/com/k3ntako/HTTPServer/ServerTest.java
+++ b/src/test/java/com/k3ntako/HTTPServer/ServerTest.java
@@ -15,17 +15,17 @@ class ServerTest {
             "\n\n";
 
     var serverIOMock = new ServerIOMock(clientInput);
-    var requestHandlerMock = new RequestHandlerMock();
+    var requestGeneratorMock = new RequestGeneratorMock();
     var socket = new ServerSocketMock();
 
     var routeRegistrar = new RouteRegistrar(new RouteRegistry(), new FileIOMock());
     var routeRegistry = routeRegistrar.registerRoutes();
     var router = new Router(routeRegistry);
 
-    var app = new Server(serverIOMock, requestHandlerMock, socket, router);
+    var app = new Server(serverIOMock, requestGeneratorMock, socket, router);
     app.run();
 
-    assertTrue( requestHandlerMock.wasHandleRequestCalled());
+    assertTrue( requestGeneratorMock.wasHandleRequestCalled());
   }
 
   @Test
@@ -43,14 +43,14 @@ class ServerTest {
             "Body line 4: def";
 
     var serverIO = new ServerIOMock(clientInput + bodyStr);
-    var requestHandlerMock = new RequestHandlerMock();
+    var requestGeneratorMock = new RequestGeneratorMock();
     var socket = new ServerSocketMock();
 
     var routeRegistrar = new RouteRegistrar(new RouteRegistry(), new FileIOMock());
     var routeRegistry = routeRegistrar.registerRoutes();
     var router = new Router(routeRegistry);
 
-    var app = new Server(serverIO, requestHandlerMock, socket, router);
+    var app = new Server(serverIO, requestGeneratorMock, socket, router);
     app.run();
 
     var expected = "HTTP/1.1 200 OK\r\n" +
@@ -75,14 +75,14 @@ class ServerTest {
         "Body line 4: def";
 
     var serverIO = new ServerIOMock(clientInput + bodyStr);
-    var requestHandlerMock = new RequestHandlerMockThrowsError();
+    var requestGeneratorMock = new RequestGeneratorMockThrowsError();
     var socket = new ServerSocketMock();
 
     var routeRegistrar = new RouteRegistrar(new RouteRegistry(), new FileIOMock());
     var routeRegistry = routeRegistrar.registerRoutes();
     var router = new Router(routeRegistry);
 
-    var app = new Server(serverIO, requestHandlerMock, socket, router);
+    var app = new Server(serverIO, requestGeneratorMock, socket, router);
     app.run();
 
     var expected = "HTTP/1.1 500 Internal Server Error\r\n" +

--- a/src/test/java/com/k3ntako/HTTPServer/ServerTest.java
+++ b/src/test/java/com/k3ntako/HTTPServer/ServerTest.java
@@ -9,10 +9,10 @@ class ServerTest {
   @Test
   void serverParsesHeader() throws Exception {
     var clientInput = "GET /simple_get_with_body HTTP/1.1\n" +
-            "Host: localhost:5000\n" +
-            "User-Agent: curl/7.64.1\n" +
-            "Accept: */*\n" +
-            "\n\n";
+        "Host: localhost:5000\n" +
+        "User-Agent: curl/7.64.1\n" +
+        "Accept: */*\n" +
+        "\n\n";
 
     var serverIOMock = new ServerIOMock(clientInput);
     var requestGeneratorMock = new RequestGeneratorMock();
@@ -21,26 +21,27 @@ class ServerTest {
     var routeRegistrar = new RouteRegistrar(new RouteRegistry(), new FileIOMock());
     var routeRegistry = routeRegistrar.registerRoutes();
     var router = new Router(routeRegistry);
+    var requestHandler = new RequestHandler(router, requestGeneratorMock);
 
-    var app = new Server(serverIOMock, requestGeneratorMock, socket, router);
+    var app = new Server(serverIOMock, requestHandler, socket, router);
     app.run();
 
-    assertTrue( requestGeneratorMock.wasHandleRequestCalled());
+    assertTrue(requestGeneratorMock.wasHandleRequestCalled());
   }
 
   @Test
   void serverReturnsInput() throws Exception {
     var clientInput = "GET /simple_get_with_body HTTP/1.1\n" +
-            "Host: localhost:5000\n" +
-            "User-Agent: curl/7.64.1\n" +
-            "Accept: */*\n" +
-            "Content-Length: 68\n" +
-            "\n\n";
+        "Host: localhost:5000\n" +
+        "User-Agent: curl/7.64.1\n" +
+        "Accept: */*\n" +
+        "Content-Length: 68\n" +
+        "\n\n";
 
     var bodyStr = "Body line 1: def\n" +
-            "Body line 2: def\n" +
-            "Body line 3: def\n" +
-            "Body line 4: def";
+        "Body line 2: def\n" +
+        "Body line 3: def\n" +
+        "Body line 4: def";
 
     var serverIO = new ServerIOMock(clientInput + bodyStr);
     var requestGeneratorMock = new RequestGeneratorMock();
@@ -49,13 +50,14 @@ class ServerTest {
     var routeRegistrar = new RouteRegistrar(new RouteRegistry(), new FileIOMock());
     var routeRegistry = routeRegistrar.registerRoutes();
     var router = new Router(routeRegistry);
+    var requestHandler = new RequestHandler(router, requestGeneratorMock);
 
-    var app = new Server(serverIO, requestGeneratorMock, socket, router);
+    var app = new Server(serverIO, requestHandler, socket, router);
     app.run();
 
     var expected = "HTTP/1.1 200 OK\r\n" +
-            "Content-Length: 11\r\n\r\n" +
-            "Hello world\n";
+        "Content-Length: 11\r\n\r\n" +
+        "Hello world\n";
 
     assertEquals(expected, serverIO.getSentData());
   }
@@ -81,8 +83,10 @@ class ServerTest {
     var routeRegistrar = new RouteRegistrar(new RouteRegistry(), new FileIOMock());
     var routeRegistry = routeRegistrar.registerRoutes();
     var router = new Router(routeRegistry);
+    var requestHandler = new RequestHandler(router, requestGeneratorMock);
+    requestHandler.useErrorHandler(new ErrorHandler());
 
-    var app = new Server(serverIO, requestGeneratorMock, socket, router);
+    var app = new Server(serverIO, requestHandler, socket, router);
     app.run();
 
     var expected = "HTTP/1.1 500 Internal Server Error\r\n" +

--- a/src/test/java/com/k3ntako/HTTPServer/mocks/RequestGeneratorMock.java
+++ b/src/test/java/com/k3ntako/HTTPServer/mocks/RequestGeneratorMock.java
@@ -1,12 +1,12 @@
 package com.k3ntako.HTTPServer.mocks;
 
 import com.k3ntako.HTTPServer.ServerIOInterface;
-import com.k3ntako.HTTPServer.RequestHandlerInterface;
+import com.k3ntako.HTTPServer.RequestGeneratorInterface;
 import com.k3ntako.HTTPServer.RequestInterface;
 
 import java.util.HashMap;
 
-public class RequestHandlerMock implements RequestHandlerInterface  {
+public class RequestGeneratorMock implements RequestGeneratorInterface {
   private String method;
   private String route;
   private String protocol;
@@ -14,7 +14,7 @@ public class RequestHandlerMock implements RequestHandlerInterface  {
   private String body;
   private boolean handleRequestCalled = false;
 
-  public RequestHandlerMock() {
+  public RequestGeneratorMock() {
     this.method = "GET";
     this.route = "/simple_get_with_body";
     this.protocol = "HTTP/1.1";
@@ -22,7 +22,7 @@ public class RequestHandlerMock implements RequestHandlerInterface  {
     this.body = "";
   }
 
-  public RequestInterface handleRequest(ServerIOInterface serverIO){
+  public RequestInterface generateRequest(ServerIOInterface serverIO){
     var request = new RequestMock(method, route, protocol, headers, body);
     handleRequestCalled = true;
     return request;

--- a/src/test/java/com/k3ntako/HTTPServer/mocks/RequestGeneratorMockThrowsError.java
+++ b/src/test/java/com/k3ntako/HTTPServer/mocks/RequestGeneratorMockThrowsError.java
@@ -1,13 +1,13 @@
 package com.k3ntako.HTTPServer.mocks;
 
 import com.k3ntako.HTTPServer.HTTPError;
-import com.k3ntako.HTTPServer.RequestHandlerInterface;
+import com.k3ntako.HTTPServer.RequestGeneratorInterface;
 import com.k3ntako.HTTPServer.RequestInterface;
 import com.k3ntako.HTTPServer.ServerIOInterface;
 
 import java.util.HashMap;
 
-public class RequestHandlerMockThrowsError implements RequestHandlerInterface  {
+public class RequestGeneratorMockThrowsError implements RequestGeneratorInterface {
   private String method;
   private String route;
   private String protocol;
@@ -15,7 +15,7 @@ public class RequestHandlerMockThrowsError implements RequestHandlerInterface  {
   private String body;
   private boolean handleRequestCalled = false;
 
-  public RequestHandlerMockThrowsError() {
+  public RequestGeneratorMockThrowsError() {
     this.method = "GET";
     this.route = "/simple_get_with_body";
     this.protocol = "HTTP/1.1";
@@ -23,7 +23,7 @@ public class RequestHandlerMockThrowsError implements RequestHandlerInterface  {
     this.body = "";
   }
 
-  public RequestInterface handleRequest(ServerIOInterface serverIO) throws HTTPError {
+  public RequestInterface generateRequest(ServerIOInterface serverIO) throws HTTPError {
     throw new HTTPError(500, "This is a test error");
   }
 

--- a/src/test/java/com/k3ntako/HTTPServer/mocks/RequestHandlerMockThrowsError.java
+++ b/src/test/java/com/k3ntako/HTTPServer/mocks/RequestHandlerMockThrowsError.java
@@ -1,0 +1,33 @@
+package com.k3ntako.HTTPServer.mocks;
+
+import com.k3ntako.HTTPServer.HTTPError;
+import com.k3ntako.HTTPServer.RequestHandlerInterface;
+import com.k3ntako.HTTPServer.RequestInterface;
+import com.k3ntako.HTTPServer.ServerIOInterface;
+
+import java.util.HashMap;
+
+public class RequestHandlerMockThrowsError implements RequestHandlerInterface  {
+  private String method;
+  private String route;
+  private String protocol;
+  private HashMap<String, String> headers;
+  private String body;
+  private boolean handleRequestCalled = false;
+
+  public RequestHandlerMockThrowsError() {
+    this.method = "GET";
+    this.route = "/simple_get_with_body";
+    this.protocol = "HTTP/1.1";
+    this.headers = new HashMap<>();
+    this.body = "";
+  }
+
+  public RequestInterface handleRequest(ServerIOInterface serverIO) throws HTTPError {
+    throw new HTTPError(500, "This is a test error");
+  }
+
+  public boolean wasHandleRequestCalled() {
+    return handleRequestCalled;
+  }
+}

--- a/src/test/java/com/k3ntako/HTTPServer/mocks/ServerIOMock.java
+++ b/src/test/java/com/k3ntako/HTTPServer/mocks/ServerIOMock.java
@@ -9,7 +9,7 @@ public class ServerIOMock implements ServerIOInterface {
   private String clientInput;
   private BufferedReader bufferedReader;
   private PrintWriterWrapperMock printWriter;
-
+  
   public ServerIOMock(String clientInput) {
     this.clientInput = clientInput;
   }


### PR DESCRIPTION
I remove most `try-catch` and exceptions bubble up to `Server`. 
- Any errors caught by `Server` will return a response (defaults to 500).
- To return a non-500 error, an `HTTPError` can be thrown. It takes in a status and a message. This can be used to return custom messages and statuses. 

If an exception is not caught by `Server`, the program will crash. 
- These are likely issues with the set-up or the connection
- Without an established connection, there is no way to return a response. 