### PR TITLE
Handle GET /reminders/:id 404

### DIFF
--- a/src/main/java/com/k3ntako/HTTPServer/RequestHandler.java
+++ b/src/main/java/com/k3ntako/HTTPServer/RequestHandler.java
@@ -16,20 +16,23 @@ public class RequestHandler {
   }
 
   public String handleRequest(ServerIOInterface serverIO) throws Exception {
-    Response response;
+    String responseStr;
     try {
       var request = this.requestGenerator.generateRequest(serverIO);
-      response = this.router.routeRequest(request);
+      var response = this.router.routeRequest(request);
+      responseStr = response.createResponse();
     } catch (HTTPError httpError) {
-      response = this.errorHandler.handleError(httpError);
+      var response = this.errorHandler.handleError(httpError);
+      responseStr = response.createResponse();
     } catch (Exception exception) {
-      response = this.errorHandler.handleError(exception);
+      var response = this.errorHandler.handleError(exception);
+      responseStr = response.createResponse();
     }
 
-    if(response == null){
+    if (responseStr == null) {
       throw new Exception("Response is null");
     }
 
-    return response.createResponse();
+    return responseStr;
   }
 }

--- a/src/main/java/com/k3ntako/HTTPServer/Response.java
+++ b/src/main/java/com/k3ntako/HTTPServer/Response.java
@@ -9,8 +9,13 @@ public class Response {
   private String body = "";
   private int status = 200;
   private HashMap<String, String> additionalHeaders = new HashMap<>();
-  
-  public String createResponse() {
+
+  public String createResponse() throws HTTPError {
+    if (body == null) {
+      throw new HTTPError(500, "Response body cannot be null");
+    }
+
+
     return this.createHeader(body.length()) + this.body;
   }
 

--- a/src/main/java/com/k3ntako/HTTPServer/controllers/Reminders.java
+++ b/src/main/java/com/k3ntako/HTTPServer/controllers/Reminders.java
@@ -32,13 +32,10 @@ public class Reminders {
     }
   }
 
-  public Response get(RequestInterface request) throws IOException, HTTPError {
+  public Response get(RequestInterface request) throws IOException {
     var params = request.getParams();
 
     var id = params.get("id");
-    if (id == null || id.isBlank()) {
-      throw new HTTPError(400, "ID must be specified");
-    }
 
     var response = new Response();
 

--- a/src/main/java/com/k3ntako/HTTPServer/controllers/Reminders.java
+++ b/src/main/java/com/k3ntako/HTTPServer/controllers/Reminders.java
@@ -32,7 +32,7 @@ public class Reminders {
     }
   }
 
-  public Response get(RequestInterface request) throws IOException {
+  public Response get(RequestInterface request) throws IOException, HTTPError {
     var params = request.getParams();
 
     var id = params.get("id");
@@ -40,6 +40,10 @@ public class Reminders {
     var response = new Response();
 
     var content = textFile.readFile(id);
+    if (content == null) {
+      throw new HTTPError(404, "Reminder was not found");
+    }
+
     response.setBody(content);
 
     return response;

--- a/src/test/java/com/k3ntako/HTTPServer/ErrorHandlerTest.java
+++ b/src/test/java/com/k3ntako/HTTPServer/ErrorHandlerTest.java
@@ -7,7 +7,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class ErrorHandlerTest {
 
   @Test
-  void handleHTTPError() {
+  void handleHTTPError() throws HTTPError {
     var httpError = new HTTPError(404, "File was not found");
     var errorHandler = new ErrorHandler();
 
@@ -22,7 +22,7 @@ class ErrorHandlerTest {
   }
 
   @Test
-  void handleServerError() {
+  void handleServerError() throws HTTPError {
     var error = new Exception("Something went wrong");
     var errorHandler = new ErrorHandler();
 

--- a/src/test/java/com/k3ntako/HTTPServer/FileIOTest.java
+++ b/src/test/java/com/k3ntako/HTTPServer/FileIOTest.java
@@ -40,6 +40,26 @@ class FileIOTest {
   }
 
   @Test
+  void readingEmptyFileReturnsEmptyString() throws IOException {
+    var file = new File(path.toString());
+    file.createNewFile();
+
+    final var fileIO = new FileIO();
+    final var fileContent = fileIO.read(path);
+
+    assertNotNull(fileContent);
+    assertEquals("", fileContent);
+  }
+
+  @Test
+  void readReturnsNullIfFileNotFound() throws IOException {
+    final var fileIO = new FileIO();
+    final var fileContent = fileIO.read(path);
+
+    assertNull(fileContent);
+  }
+
+  @Test
   void writeToFileInFolder() throws IOException {
     final var str = "This is text\nthis is a new line!";
 
@@ -50,7 +70,6 @@ class FileIOTest {
 
     assertEquals(str, fileContent);
   }
-
 
   @AfterEach
   void tearDown() throws IOException {

--- a/src/test/java/com/k3ntako/HTTPServer/RequestHandlerTest.java
+++ b/src/test/java/com/k3ntako/HTTPServer/RequestHandlerTest.java
@@ -23,4 +23,22 @@ class RequestHandlerTest {
     var responseStr = requestHandler.handleRequest(new ServerIOMock(""));
     assertEquals(expectedResponse, responseStr);
   }
+
+  @Test
+  void handlesError() throws Exception {
+    var textFile = new TextFile(new FileIOMock(), new UUID());
+    var routeRegistrar = new RouteRegistrar(new RouteRegistry(), new FileIOMock(), textFile);
+    var routeRegistry = routeRegistrar.registerRoutes();
+
+    var router = new Router(routeRegistry);
+
+    var requestHandler = new RequestHandler(router, new RequestGeneratorMockThrowsError(), new ErrorHandler());
+
+    var expectedResponse = "HTTP/1.1 500 Internal Server Error\r\n" +
+        "Content-Length: 20\r\n\r\n" +
+        "This is a test error";
+
+    var responseStr = requestHandler.handleRequest(new ServerIOMock(""));
+    assertEquals(expectedResponse, responseStr);
+  }
 }

--- a/src/test/java/com/k3ntako/HTTPServer/ResponseTest.java
+++ b/src/test/java/com/k3ntako/HTTPServer/ResponseTest.java
@@ -7,43 +7,43 @@ import static org.junit.jupiter.api.Assertions.*;
 class ResponseTest {
 
   @Test
-  void createEmptyResponse() {
+  void createEmptyResponse() throws HTTPError {
     var response = new Response();
 
     var headerStr = response.createResponse();
 
     var expected = "HTTP/1.1 200 OK\r\n" +
-            "Content-Length: 0\r\n\r\n";
+        "Content-Length: 0\r\n\r\n";
     assertEquals(expected, headerStr);
   }
 
   @Test
-  void createResponseWithBody() {
+  void createResponseWithBody() throws HTTPError {
     var response = new Response();
     response.setBody("This\nis\nthe\nresponse\nbody!!");
 
     var headerStr = response.createResponse();
 
     var expected = "HTTP/1.1 200 OK\r\n" +
-            "Content-Length: 27\r\n\r\n" +
-            "This\nis\nthe\nresponse\nbody!!";
+        "Content-Length: 27\r\n\r\n" +
+        "This\nis\nthe\nresponse\nbody!!";
     assertEquals(expected, headerStr);
   }
 
   @Test
-  void setStatus() {
+  void setStatus() throws HTTPError {
     var response = new Response();
     response.setStatus(404);
 
     var headerStr = response.createResponse();
     var expected = "HTTP/1.1 404 Not Found\r\n" +
-            "Content-Length: 0\r\n\r\n";
+        "Content-Length: 0\r\n\r\n";
 
     assertEquals(expected, headerStr);
   }
 
   @Test
-  void addHeader() {
+  void addHeader() throws HTTPError {
     var response = new Response();
     response.setStatus(301);
     response.addHeader("Location", "/simple_get");
@@ -51,23 +51,36 @@ class ResponseTest {
     var headerStr = response.createResponse();
 
     var expected = "HTTP/1.1 301 Moved Permanently\r\n" +
-            "Location: /simple_get\r\n" +
-            "Content-Length: 0\r\n\r\n";
+        "Location: /simple_get\r\n" +
+        "Content-Length: 0\r\n\r\n";
 
     assertEquals(expected, headerStr);
   }
 
   @Test
-  void setRedirect() {
+  void setRedirect() throws HTTPError {
     var response = new Response();
     response.setRedirect("/test", 302);
 
     var headerStr = response.createResponse();
 
     var expected = "HTTP/1.1 302 Found\r\n" +
-            "Location: /test\r\n" +
-            "Content-Length: 0\r\n\r\n";
+        "Location: /test\r\n" +
+        "Content-Length: 0\r\n\r\n";
 
     assertEquals(expected, headerStr);
+  }
+
+  @Test
+  void throwErrorIfBodyIsNull() {
+    var response = new Response();
+    response.setBody(null);
+
+    HTTPError exception = assertThrows(
+        HTTPError.class, response::createResponse
+    );
+
+    assertEquals("Response body cannot be null", exception.getMessage());
+    assertEquals(500, exception.getStatus());
   }
 }

--- a/src/test/java/com/k3ntako/HTTPServer/controllers/AccountTest.java
+++ b/src/test/java/com/k3ntako/HTTPServer/controllers/AccountTest.java
@@ -1,5 +1,6 @@
 package com.k3ntako.HTTPServer.controllers;
 
+import com.k3ntako.HTTPServer.HTTPError;
 import com.k3ntako.HTTPServer.mocks.RequestMock;
 import org.junit.jupiter.api.Test;
 
@@ -10,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class AccountTest {
 
   @Test
-  void getResponse() {
+  void getResponse() throws HTTPError {
     var request = new RequestMock("GET", "/account", "HTTP/1.1", new HashMap<>(), "");
 
     var account = new Account();

--- a/src/test/java/com/k3ntako/HTTPServer/controllers/AdminTest.java
+++ b/src/test/java/com/k3ntako/HTTPServer/controllers/AdminTest.java
@@ -1,5 +1,6 @@
 package com.k3ntako.HTTPServer.controllers;
 
+import com.k3ntako.HTTPServer.HTTPError;
 import com.k3ntako.HTTPServer.mocks.RequestMock;
 import org.junit.jupiter.api.Test;
 
@@ -10,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class AdminTest {
 
   @Test
-  void getResponse() {
+  void getResponse() throws HTTPError {
     var request = new RequestMock("GET", "/admin", "HTTP/1.1", new HashMap<>(), "");
 
     var admin = new Admin();

--- a/src/test/java/com/k3ntako/HTTPServer/controllers/NotFoundTest.java
+++ b/src/test/java/com/k3ntako/HTTPServer/controllers/NotFoundTest.java
@@ -1,5 +1,6 @@
 package com.k3ntako.HTTPServer.controllers;
 
+import com.k3ntako.HTTPServer.HTTPError;
 import com.k3ntako.HTTPServer.Request;
 import com.k3ntako.HTTPServer.mocks.ServerIOMock;
 import org.junit.jupiter.api.Test;
@@ -9,7 +10,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class NotFoundTest {
 
   @Test
-  void getResponse() {
+  void getResponse() throws HTTPError {
     var notFound = new NotFound();
     var serverIO = new ServerIOMock("GET / HTTP/1.1");
     var response = notFound.handleNotFound(new Request(serverIO));

--- a/src/test/java/com/k3ntako/HTTPServer/controllers/RemindersTest.java
+++ b/src/test/java/com/k3ntako/HTTPServer/controllers/RemindersTest.java
@@ -91,4 +91,30 @@ class RemindersTest {
 
     assertEquals(expectedResponse, response.createResponse());
   }
+
+
+  @Test
+  void getThrows404IfFileIsNotFound() {
+    var request = new RequestMock(
+        "GET",
+        "/reminders/not-an-id"
+    );
+
+    var params = new HashMap<String, String>();
+    params.put("id", "not-an-id");
+    request.setParams(params);
+
+    var fileIOMock = new FileIOMock(null);
+
+    var textFile = new TextFile(fileIOMock, new UUID());
+    var reminders = new Reminders(textFile);
+
+    HTTPError exception = assertThrows(
+        HTTPError.class,
+        () -> reminders.get(request)
+    );
+
+    assertEquals("Reminder was not found", exception.getMessage());
+    assertEquals(404, exception.getStatus());
+  }
 }

--- a/src/test/java/com/k3ntako/HTTPServer/controllers/SimpleGetTest.java
+++ b/src/test/java/com/k3ntako/HTTPServer/controllers/SimpleGetTest.java
@@ -1,5 +1,6 @@
 package com.k3ntako.HTTPServer.controllers;
 
+import com.k3ntako.HTTPServer.HTTPError;
 import com.k3ntako.HTTPServer.mocks.RequestMock;
 import org.junit.jupiter.api.Test;
 
@@ -10,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class SimpleGetTest {
 
   @Test
-  void getResponse() {
+  void getResponse() throws HTTPError {
     var request = new RequestMock("GET", "/simple_get", "HTTP/1.1", new HashMap<>(), "");
 
     var simpleGet = new SimpleGet();

--- a/src/test/java/com/k3ntako/HTTPServer/controllers/SimpleGetWithBodyTest.java
+++ b/src/test/java/com/k3ntako/HTTPServer/controllers/SimpleGetWithBodyTest.java
@@ -1,5 +1,6 @@
 package com.k3ntako.HTTPServer.controllers;
 
+import com.k3ntako.HTTPServer.HTTPError;
 import com.k3ntako.HTTPServer.mocks.RequestMock;
 import org.junit.jupiter.api.Test;
 
@@ -10,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class SimpleGetWithBodyTest {
 
   @Test
-  void getResponse() {
+  void getResponse() throws HTTPError {
     var request = new RequestMock("GET", "/simple_get_with_body", "HTTP/1.1", new HashMap<>(), "");
 
     var simpleGetWithBody = new SimpleGetWithBody();


### PR DESCRIPTION
1. Improved how error is handled in `ErrorHandler`
    - Previously, if `response.createResponse()` threw an error, it was not caught. 
    - `response.createResponse()` has been moved inside the `try/catch`
2. `Reminders.get()` returns a 404 if the reminders file is not found.