### PR TITLE
Patch reminders

### DIFF
--- a/src/main/java/com/k3ntako/HTTPServer/FileIO.java
+++ b/src/main/java/com/k3ntako/HTTPServer/FileIO.java
@@ -6,6 +6,7 @@ import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 
 public class FileIO implements FileIOInterface {
   @Override
@@ -39,5 +40,16 @@ public class FileIO implements FileIOInterface {
     var fileURI = fileURL.toURI();
     var path = Paths.get(fileURI);
     return read(path);
+  }
+
+  public void patchNewLine(Path path, String str) throws IOException {
+    var file = new File(path.toString());
+
+    if (!file.exists()) {
+      throw new IOException("File does not exist");
+    }
+
+    str = System.lineSeparator() + str;
+    Files.write(path, str.getBytes(), StandardOpenOption.APPEND);
   }
 }

--- a/src/main/java/com/k3ntako/HTTPServer/FileIOInterface.java
+++ b/src/main/java/com/k3ntako/HTTPServer/FileIOInterface.java
@@ -7,5 +7,6 @@ import java.nio.file.Path;
 public interface FileIOInterface {
     void write(Path path, String str) throws IOException;
     String read(Path path) throws IOException;
+    void patchNewLine(Path path, String str) throws IOException;
     String getResource(String fileName) throws IOException, URISyntaxException;
 }

--- a/src/main/java/com/k3ntako/HTTPServer/Request.java
+++ b/src/main/java/com/k3ntako/HTTPServer/Request.java
@@ -11,7 +11,7 @@ public class Request implements RequestInterface {
   private HashMap<String, String> headers;
   private String body;
   private ServerIOInterface serverIO;
-  private HashMap<String, String> params;
+  private HashMap<String, String> routeParams;
 
   public Request(ServerIOInterface serverIO) {
     this.serverIO = serverIO;
@@ -82,16 +82,16 @@ public class Request implements RequestInterface {
     this.body = bodyStr;
   }
 
-  public void setParams(HashMap<String, String> params) {
-    this.params = params;
+  public void setRouteParams(HashMap<String, String> routeParams) {
+    this.routeParams = routeParams;
   }
 
-  public HashMap<String, String> getParams() {
-    return this.params;
+  public HashMap<String, String> getRouteParams() {
+    return this.routeParams;
   }
 
-  public String getParam(String key) {
-    return this.params.get(key);
+  public String getRouteParam(String key) {
+    return this.routeParams.get(key);
   }
 
   public String getMethod() {

--- a/src/main/java/com/k3ntako/HTTPServer/Request.java
+++ b/src/main/java/com/k3ntako/HTTPServer/Request.java
@@ -90,6 +90,10 @@ public class Request implements RequestInterface {
     return this.params;
   }
 
+  public String getParam(String key) {
+    return this.params.get(key);
+  }
+
   public String getMethod() {
     return this.method;
   }

--- a/src/main/java/com/k3ntako/HTTPServer/RequestInterface.java
+++ b/src/main/java/com/k3ntako/HTTPServer/RequestInterface.java
@@ -10,6 +10,8 @@ public interface RequestInterface {
 
   HashMap<String, String> getParams();
 
+  String getParam(String key);
+
   String getMethod();
 
   String getRoute();

--- a/src/main/java/com/k3ntako/HTTPServer/RequestInterface.java
+++ b/src/main/java/com/k3ntako/HTTPServer/RequestInterface.java
@@ -6,11 +6,11 @@ import java.util.HashMap;
 public interface RequestInterface {
   void parseRequest() throws IOException;
 
-  void setParams(HashMap<String, String> params);
+  void setRouteParams(HashMap<String, String> routeParams);
 
-  HashMap<String, String> getParams();
+  HashMap<String, String> getRouteParams();
 
-  String getParam(String key);
+  String getRouteParam(String key);
 
   String getMethod();
 

--- a/src/main/java/com/k3ntako/HTTPServer/Response.java
+++ b/src/main/java/com/k3ntako/HTTPServer/Response.java
@@ -15,17 +15,23 @@ public class Response {
       throw new HTTPError(500, "Response body cannot be null");
     }
 
-
     return this.createHeader(body.length()) + this.body;
   }
 
   private String createHeader(int contentLength) {
+    var status = this.status;
+
+    if (body.length() == 0 && status >= 200 && status <= 299) {
+      status = 204;
+    }
+
     var header = "HTTP/1.1 " + status + " " + Status.fromStatusCode(status) + "\r\n";
 
     var additionalHeaders = stringifyAdditionHeaders();
     header += additionalHeaders;
 
     header += "Content-Length: " + contentLength + "\r\n\r\n";
+
 
     return header;
   }

--- a/src/main/java/com/k3ntako/HTTPServer/Route.java
+++ b/src/main/java/com/k3ntako/HTTPServer/Route.java
@@ -5,7 +5,7 @@ import java.util.HashMap;
 public class Route {
   private String path;
   private ControllerMethodInterface controllerMethod;
-  private HashMap<String, String> params = new HashMap<>();
+  private HashMap<String, String> routeParams = new HashMap<>();
 
   public Route(String path) {
     this.path = path;
@@ -23,11 +23,11 @@ public class Route {
     return this.controllerMethod;
   }
 
-  public void setParams(HashMap<String, String> params) {
-    this.params = params;
+  public void setRouteParams(HashMap<String, String> routeParams) {
+    this.routeParams = routeParams;
   }
 
-  public HashMap<String, String> getParams() {
-    return this.params;
+  public HashMap<String, String> getRouteParams() {
+    return this.routeParams;
   }
 }

--- a/src/main/java/com/k3ntako/HTTPServer/RouteMatcher.java
+++ b/src/main/java/com/k3ntako/HTTPServer/RouteMatcher.java
@@ -64,7 +64,7 @@ public class RouteMatcher {
         }
 
         route.setControllerMethod(controllerMethod);
-        route.setParams(this.getParams(registeredRoute, requestRoute));
+        route.setRouteParams(this.parseRouteParams(registeredRoute, requestRoute));
         return route;
       }
     }
@@ -108,8 +108,8 @@ public class RouteMatcher {
     return true;
   }
 
-  private HashMap<String, String> getParams(String registeredRoute, String requestRoute) {
-    var params = new HashMap<String, String>();
+  private HashMap<String, String> parseRouteParams(String registeredRoute, String requestRoute) {
+    var routeParams = new HashMap<String, String>();
 
     var registeredParts = convertToArray(registeredRoute);
     var requestParts = convertToArray(requestRoute);
@@ -120,10 +120,10 @@ public class RouteMatcher {
 
       if (registeredPart.charAt(0) == ':') {
         var paramKey = registeredPart.substring(1);
-        params.put(paramKey, requestPart);
+        routeParams.put(paramKey, requestPart);
       }
     }
 
-    return params;
+    return routeParams;
   }
 }

--- a/src/main/java/com/k3ntako/HTTPServer/RouteRegistrar.java
+++ b/src/main/java/com/k3ntako/HTTPServer/RouteRegistrar.java
@@ -20,7 +20,7 @@ public class RouteRegistrar {
     routeRegistry.registerRoute("GET", "/account", (RequestInterface req) -> new Account().get(req));
     routeRegistry.registerRoute("POST", "/reminders", (RequestInterface req) -> new Reminders(textFile).post(req));
     routeRegistry.registerRoute("GET", "/reminders/:id", (RequestInterface req) -> new Reminders(textFile).get(req));
-    routeRegistry.registerRoute("PATCH", "/reminders/:id", (RequestInterface req) -> new Reminders(textFile).get(req));
+    routeRegistry.registerRoute("PATCH", "/reminders/:id", (RequestInterface req) -> new Reminders(textFile).patch(req));
 
     return routeRegistry;
   }

--- a/src/main/java/com/k3ntako/HTTPServer/RouteRegistrar.java
+++ b/src/main/java/com/k3ntako/HTTPServer/RouteRegistrar.java
@@ -20,6 +20,7 @@ public class RouteRegistrar {
     routeRegistry.registerRoute("GET", "/account", (RequestInterface req) -> new Account().get(req));
     routeRegistry.registerRoute("POST", "/reminders", (RequestInterface req) -> new Reminders(textFile).post(req));
     routeRegistry.registerRoute("GET", "/reminders/:id", (RequestInterface req) -> new Reminders(textFile).get(req));
+    routeRegistry.registerRoute("PATCH", "/reminders/:id", (RequestInterface req) -> new Reminders(textFile).get(req));
 
     return routeRegistry;
   }

--- a/src/main/java/com/k3ntako/HTTPServer/Router.java
+++ b/src/main/java/com/k3ntako/HTTPServer/Router.java
@@ -18,7 +18,7 @@ public class Router {
 
     if(route != null) {
       controllerMethod = route.getControllerMethod();
-      request.setParams(route.getParams());
+      request.setRouteParams(route.getRouteParams());
     }
 
     return controllerMethod.getResponse(request);

--- a/src/main/java/com/k3ntako/HTTPServer/TextFile.java
+++ b/src/main/java/com/k3ntako/HTTPServer/TextFile.java
@@ -5,8 +5,8 @@ import java.nio.file.FileSystems;
 import java.nio.file.Path;
 
 public class TextFile {
-  private FileIOInterface fileIO;
-  private UUIDInterface uuid;
+  private final FileIOInterface fileIO;
+  private final UUIDInterface uuid;
 
   public TextFile(FileIOInterface fileIO, UUIDInterface uuid) {
     this.fileIO = fileIO;
@@ -15,8 +15,7 @@ public class TextFile {
 
   public String saveFile(String text) throws IOException {
     var fileUUID = uuid.generate();
-    var filePath = "./data/" + fileUUID + ".txt";
-    Path path = FileSystems.getDefault().getPath(filePath);
+    var path = generatePathForUUID(fileUUID);
 
     fileIO.write(path, text);
 
@@ -24,9 +23,19 @@ public class TextFile {
   }
 
   public String readFile(String fileUUID) throws IOException {
-    var filePath = "./data/" + fileUUID + ".txt";
-    Path path = FileSystems.getDefault().getPath(filePath);
+    var path = generatePathForUUID(fileUUID);
 
     return fileIO.read(path);
+  }
+
+  public void patchFile(String fileUUID, String text) throws IOException {
+    var path = generatePathForUUID(fileUUID);
+
+    fileIO.patchNewLine(path, text);
+  }
+
+  private Path generatePathForUUID(String fileUUID) {
+    var strPath = "./data/" + fileUUID + ".txt";
+    return FileSystems.getDefault().getPath(strPath);
   }
 }

--- a/src/main/java/com/k3ntako/HTTPServer/controllers/Reminders.java
+++ b/src/main/java/com/k3ntako/HTTPServer/controllers/Reminders.java
@@ -49,14 +49,17 @@ public class Reminders {
     return response;
   }
 
-  public Response patch(RequestInterface request) throws IOException, HTTPError {
+  public Response patch(RequestInterface request) throws HTTPError {
     var body = request.getBody();
-    validateBody(body);
 
     var params = request.getParams();
     var id = params.get("id");
 
-    textFile.patchFile(id, body);
+    try {
+      textFile.patchFile(id, body);
+    } catch (IOException e) {
+      throw new HTTPError(404, "Reminder was not found");
+    }
 
     return new Response();
   }

--- a/src/main/java/com/k3ntako/HTTPServer/controllers/Reminders.java
+++ b/src/main/java/com/k3ntako/HTTPServer/controllers/Reminders.java
@@ -48,4 +48,16 @@ public class Reminders {
 
     return response;
   }
+
+  public Response patch(RequestInterface request) throws IOException, HTTPError {
+    var body = request.getBody();
+    validateBody(body);
+
+    var params = request.getParams();
+    var id = params.get("id");
+
+    textFile.patchFile(id, body);
+
+    return new Response();
+  }
 }

--- a/src/main/java/com/k3ntako/HTTPServer/controllers/Reminders.java
+++ b/src/main/java/com/k3ntako/HTTPServer/controllers/Reminders.java
@@ -1,11 +1,8 @@
 package com.k3ntako.HTTPServer.controllers;
 
 import com.k3ntako.HTTPServer.*;
-import org.w3c.dom.Text;
 
 import java.io.IOException;
-import java.nio.file.FileSystems;
-import java.nio.file.Path;
 
 public class Reminders {
   private TextFile textFile;
@@ -33,7 +30,7 @@ public class Reminders {
   }
 
   public Response get(RequestInterface request) throws IOException, HTTPError {
-    var id = request.getParam("id");
+    var id = request.getRouteParam("id");
 
     var response = new Response();
 
@@ -51,7 +48,7 @@ public class Reminders {
     var body = request.getBody();
     validateBody(body);
 
-    var id = request.getParam("id");
+    var id = request.getRouteParam("id");
 
     try {
       textFile.patchFile(id, body);

--- a/src/main/java/com/k3ntako/HTTPServer/controllers/Reminders.java
+++ b/src/main/java/com/k3ntako/HTTPServer/controllers/Reminders.java
@@ -33,9 +33,7 @@ public class Reminders {
   }
 
   public Response get(RequestInterface request) throws IOException, HTTPError {
-    var params = request.getParams();
-
-    var id = params.get("id");
+    var id = request.getParam("id");
 
     var response = new Response();
 
@@ -53,8 +51,7 @@ public class Reminders {
     var body = request.getBody();
     validateBody(body);
 
-    var params = request.getParams();
-    var id = params.get("id");
+    var id = request.getParam("id");
 
     try {
       textFile.patchFile(id, body);

--- a/src/main/java/com/k3ntako/HTTPServer/controllers/Reminders.java
+++ b/src/main/java/com/k3ntako/HTTPServer/controllers/Reminders.java
@@ -51,6 +51,7 @@ public class Reminders {
 
   public Response patch(RequestInterface request) throws HTTPError {
     var body = request.getBody();
+    validateBody(body);
 
     var params = request.getParams();
     var id = params.get("id");

--- a/src/test/java/com/k3ntako/HTTPServer/FileIOTest.java
+++ b/src/test/java/com/k3ntako/HTTPServer/FileIOTest.java
@@ -71,6 +71,31 @@ class FileIOTest {
     assertEquals(str, fileContent);
   }
 
+  @Test
+  void patch() throws IOException {
+    final var str = "This is the first line";
+    Files.write(path, str.getBytes());
+
+    final var patchStr = "This is the second line";
+    final var fileIO = new FileIO();
+    fileIO.patchNewLine(path, patchStr);
+
+    final var fileContent = Files.readString(path);
+
+    final var expected = str + "\n" + patchStr;
+    assertEquals(expected, fileContent);
+  }
+
+  @Test
+  void patchThrowsErrorIfDoesNotExist() {
+    final var patchStr = "This is the second line";
+    final var fileIO = new FileIO();
+
+    IOException exception = assertThrows(IOException.class, () -> fileIO.patchNewLine(path, patchStr));
+
+    assertEquals("File does not exist", exception.getMessage());
+  }
+
   @AfterEach
   void tearDown() throws IOException {
     Files.deleteIfExists(path);

--- a/src/test/java/com/k3ntako/HTTPServer/RequestTest.java
+++ b/src/test/java/com/k3ntako/HTTPServer/RequestTest.java
@@ -72,4 +72,25 @@ class RequestTest {
     assertEquals("123", requestParams.get("id"));
     assertEquals("345", requestParams.get("event_id"));
   }
+
+  @Test
+  void getParam() {
+    var headerStr = "GET / HTTP/1.1\r\n" +
+        "Host: localhost:5000\r\n" +
+        "User-Agent: curl/7.64.1\r\n" +
+        "Accept: */*\r\n\r\n";
+    var serverIO = new ServerIOMock(headerStr);
+    serverIO.init(new Socket());
+
+    var request = new Request(serverIO);
+
+    var params = new HashMap<String, String>();
+    params.put("id", "123");
+    params.put("event_id", "345");
+
+    request.setParams(params);
+
+    assertEquals("123", request.getParam("id"));
+    assertEquals("345", request.getParam("event_id"));
+  }
 }

--- a/src/test/java/com/k3ntako/HTTPServer/RequestTest.java
+++ b/src/test/java/com/k3ntako/HTTPServer/RequestTest.java
@@ -51,7 +51,7 @@ class RequestTest {
   }
 
   @Test
-  void getAndSetParams() {
+  void getAndSetRouteParams() {
     var headerStr = "GET / HTTP/1.1\r\n" +
         "Host: localhost:5000\r\n" +
         "User-Agent: curl/7.64.1\r\n" +
@@ -61,20 +61,20 @@ class RequestTest {
 
     var request = new Request(serverIO);
 
-    var params = new HashMap<String, String>();
-    params.put("id", "123");
-    params.put("event_id", "345");
+    var routeParams = new HashMap<String, String>();
+    routeParams.put("id", "123");
+    routeParams.put("event_id", "345");
 
-    request.setParams(params);
+    request.setRouteParams(routeParams);
 
-    var requestParams = request.getParams();
+    var requestParams = request.getRouteParams();
 
     assertEquals("123", requestParams.get("id"));
     assertEquals("345", requestParams.get("event_id"));
   }
 
   @Test
-  void getParam() {
+  void getRouteParam() {
     var headerStr = "GET / HTTP/1.1\r\n" +
         "Host: localhost:5000\r\n" +
         "User-Agent: curl/7.64.1\r\n" +
@@ -84,13 +84,13 @@ class RequestTest {
 
     var request = new Request(serverIO);
 
-    var params = new HashMap<String, String>();
-    params.put("id", "123");
-    params.put("event_id", "345");
+    var routeParams = new HashMap<String, String>();
+    routeParams.put("id", "123");
+    routeParams.put("event_id", "345");
 
-    request.setParams(params);
+    request.setRouteParams(routeParams);
 
-    assertEquals("123", request.getParam("id"));
-    assertEquals("345", request.getParam("event_id"));
+    assertEquals("123", request.getRouteParam("id"));
+    assertEquals("345", request.getRouteParam("event_id"));
   }
 }

--- a/src/test/java/com/k3ntako/HTTPServer/ResponseTest.java
+++ b/src/test/java/com/k3ntako/HTTPServer/ResponseTest.java
@@ -12,7 +12,7 @@ class ResponseTest {
 
     var headerStr = response.createResponse();
 
-    var expected = "HTTP/1.1 200 OK\r\n" +
+    var expected = "HTTP/1.1 204 No Content\r\n" +
         "Content-Length: 0\r\n\r\n";
     assertEquals(expected, headerStr);
   }

--- a/src/test/java/com/k3ntako/HTTPServer/RouteMatcherTest.java
+++ b/src/test/java/com/k3ntako/HTTPServer/RouteMatcherTest.java
@@ -27,7 +27,7 @@ class RouteMatcherTest {
     var route = routeMatcher.matchRoute(routes, request);
 
     assertNotNull(route.getControllerMethod());
-    assertNotNull(route.getParams());
+    assertNotNull(route.getRouteParams());
   }
 
   @Test
@@ -47,9 +47,9 @@ class RouteMatcherTest {
     assertNotNull(route.getControllerMethod());
     assertEquals("/reminders/8d142d80-565f-417d-8334-a8a19caadadb", route.getRoutePath());
 
-    var params = route.getParams();
-    assertNotNull(params);
-    assertEquals("8d142d80-565f-417d-8334-a8a19caadadb", params.get("id"));
+    var routeParams = route.getRouteParams();
+    assertNotNull(routeParams);
+    assertEquals("8d142d80-565f-417d-8334-a8a19caadadb", routeParams.get("id"));
   }
 
   @Test

--- a/src/test/java/com/k3ntako/HTTPServer/RouteRegistryTest.java
+++ b/src/test/java/com/k3ntako/HTTPServer/RouteRegistryTest.java
@@ -91,9 +91,9 @@ class RouteRegistryTest {
     routeRegistry.registerRoute("GET", "/reminders/:id", (RequestInterface req) -> new Reminders(textFile).get(req));
 
     var request = new RequestMock("GET", "/reminders/" + mockUUID.getDefaultUUID());
-    var params = new HashMap<String, String>();
-    params.put("id", mockUUID.getDefaultUUID());
-    request.setParams(params);
+    var routeParams = new HashMap<String, String>();
+    routeParams.put("id", mockUUID.getDefaultUUID());
+    request.setRouteParams(routeParams);
     var remindersGet = routeRegistry.getController(request);
 
     assertNotNull(remindersGet);

--- a/src/test/java/com/k3ntako/HTTPServer/RouteTest.java
+++ b/src/test/java/com/k3ntako/HTTPServer/RouteTest.java
@@ -27,16 +27,16 @@ class RouteTest {
   }
 
   @Test
-  void getAndSetParams() {
+  void getAndSetRouteParams() {
     var route = new Route("/reminders/123");
     var textFile = new TextFile(new   FileIOMock(), new UUID());
     route.setControllerMethod((RequestInterface req) -> new Reminders(textFile).get(req));
 
-    var params = new HashMap<String, String>();
-    params.put("id", "123");
-    route.setParams(params);
+    var routeParams = new HashMap<String, String>();
+    routeParams.put("id", "123");
+    route.setRouteParams(routeParams);
 
-    var paramFromRoute = route.getParams();
+    var paramFromRoute = route.getRouteParams();
     assertEquals("123", paramFromRoute.get("id"));
   }
 }

--- a/src/test/java/com/k3ntako/HTTPServer/TextFileTest.java
+++ b/src/test/java/com/k3ntako/HTTPServer/TextFileTest.java
@@ -33,4 +33,17 @@ class TextFileTest {
     assertEquals("test file str", fileStr);
     assertEquals("./data/8d142d80-565f-417d-8334-a8a19caadadb.txt", fileIO.getLastReadPath().toString());
   }
+
+  @Test
+  void patchFile() throws IOException {
+    var fileIO = new FileIOMock();
+    var uuid = new UUIDMock();
+    var textFile = new TextFile(fileIO, uuid);
+
+    textFile.patchFile(uuid.getDefaultUUID(), "Here is the patch text");
+
+    var pathStr = fileIO.getLastPatchPath().toString();
+    assertEquals("./data/8d142d80-565f-417d-8334-a8a19caadadb.txt", pathStr);
+    assertEquals("Here is the patch text", fileIO.getLastPatch());
+  }
 }

--- a/src/test/java/com/k3ntako/HTTPServer/controllers/RemindersTest.java
+++ b/src/test/java/com/k3ntako/HTTPServer/controllers/RemindersTest.java
@@ -128,7 +128,7 @@ class RemindersTest {
 
   @Test
   void patchReturns404IfFileNotFound() {
-    var request = new RequestMock("GET", "/reminders/not-an-id");
+    var request = new RequestMock("PATCH", "/reminders/not-an-id");
 
     var params = new HashMap<String, String>();
     params.put("id", "not-an-id");
@@ -143,5 +143,24 @@ class RemindersTest {
 
     assertEquals("Reminder was not found", exception.getMessage());
     assertEquals(404, exception.getStatus());
+  }
+
+  @Test
+  void patchThrowsErrorIfBodyIsMultipleLines() {
+    var mockUUID = new UUIDMock();
+    var patchBody = "hello post!\nsecond line";
+    var request = new RequestMock("PATCH", "/reminders", patchBody);
+
+    var params = new HashMap<String, String>();
+    params.put("id", mockUUID.getDefaultUUID());
+    request.setParams(params);
+
+    var textFile = new TextFile(new FileIOMock(), mockUUID);
+    var reminders = new Reminders(textFile);
+
+    HTTPError exception = assertThrows(HTTPError.class, () -> reminders.patch(request));
+
+    assertEquals("Request body should not be multiline", exception.getMessage());
+    assertEquals(400, exception.getStatus());
   }
 }

--- a/src/test/java/com/k3ntako/HTTPServer/controllers/RemindersTest.java
+++ b/src/test/java/com/k3ntako/HTTPServer/controllers/RemindersTest.java
@@ -39,9 +39,7 @@ class RemindersTest {
     var response = reminders.post(request);
     var responseStr = response.createResponse();
 
-    var expectedResponse = "HTTP/1.1 200 OK\r\n" +
-        "Content-Length: 36\r\n\r\n" +
-        "8d142d80-565f-417d-8334-a8a19caadadb";
+    var expectedResponse = "HTTP/1.1 200 OK\r\n" + "Content-Length: 36\r\n\r\n" + "8d142d80-565f-417d-8334-a8a19caadadb";
 
     assertEquals(expectedResponse, responseStr);
   }
@@ -54,10 +52,7 @@ class RemindersTest {
     var textFile = new TextFile(new FileIOMock(), new UUIDMock());
     var reminders = new Reminders(textFile);
 
-    HTTPError exception = assertThrows(
-        HTTPError.class,
-        () -> reminders.post(request)
-    );
+    HTTPError exception = assertThrows(HTTPError.class, () -> reminders.post(request));
 
     assertEquals("Request body should not be multiline", exception.getMessage());
     assertEquals(400, exception.getStatus());
@@ -68,10 +63,7 @@ class RemindersTest {
     var mockUUID = new UUIDMock();
 
     var content = "text file content!";
-    var request = new RequestMock(
-        "GET",
-        "/reminders/" + mockUUID.getDefaultUUID()
-    );
+    var request = new RequestMock("GET", "/reminders/" + mockUUID.getDefaultUUID());
 
     var params = new HashMap<String, String>();
     params.put("id", mockUUID.getDefaultUUID());
@@ -85,9 +77,7 @@ class RemindersTest {
 
     assertEquals("./data/" + mockUUID.getDefaultUUID() + ".txt", fileIOMock.getLastReadPath().toString());
 
-    var expectedResponse = "HTTP/1.1 200 OK\r\n" +
-        "Content-Length: 18\r\n\r\n" +
-        content;
+    var expectedResponse = "HTTP/1.1 200 OK\r\n" + "Content-Length: 18\r\n\r\n" + content;
 
     assertEquals(expectedResponse, response.createResponse());
   }
@@ -95,39 +85,29 @@ class RemindersTest {
 
   @Test
   void getThrows404IfFileIsNotFound() {
-    var request = new RequestMock(
-        "GET",
-        "/reminders/not-an-id"
-    );
+    var request = new RequestMock("GET", "/reminders/not-an-id");
 
     var params = new HashMap<String, String>();
     params.put("id", "not-an-id");
     request.setParams(params);
 
-    var fileIOMock = new FileIOMock(null);
+    var fileIOMock = new FileIOMock((String) null);
 
     var textFile = new TextFile(fileIOMock, new UUID());
     var reminders = new Reminders(textFile);
 
-    HTTPError exception = assertThrows(
-        HTTPError.class,
-        () -> reminders.get(request)
-    );
+    HTTPError exception = assertThrows(HTTPError.class, () -> reminders.get(request));
 
     assertEquals("Reminder was not found", exception.getMessage());
     assertEquals(404, exception.getStatus());
   }
 
   @Test
-  void patch() throws IOException, HTTPError {
+  void patch() throws HTTPError {
     var mockUUID = new UUIDMock();
 
     var content = "text file content!";
-    var request = new RequestMock(
-        "PATCH",
-        "/reminders/" + mockUUID.getDefaultUUID(),
-        "Hello world"
-    );
+    var request = new RequestMock("PATCH", "/reminders/" + mockUUID.getDefaultUUID(), "Hello world");
 
     var params = new HashMap<String, String>();
     params.put("id", mockUUID.getDefaultUUID());
@@ -141,9 +121,27 @@ class RemindersTest {
 
     assertEquals("./data/" + mockUUID.getDefaultUUID() + ".txt", fileIOMock.getLastPatchPath().toString());
 
-    var expectedResponse = "HTTP/1.1 200 OK\r\n" +
-        "Content-Length: 0\r\n\r\n";
+    var expectedResponse = "HTTP/1.1 200 OK\r\n" + "Content-Length: 0\r\n\r\n";
 
     assertEquals(expectedResponse, response.createResponse());
+  }
+
+  @Test
+  void patchReturns404IfFileNotFound() {
+    var request = new RequestMock("GET", "/reminders/not-an-id");
+
+    var params = new HashMap<String, String>();
+    params.put("id", "not-an-id");
+    request.setParams(params);
+
+    var fileIOMock = new FileIOMock(new IOException("File does not exist"));
+
+    var textFile = new TextFile(fileIOMock, new UUID());
+    var reminders = new Reminders(textFile);
+
+    HTTPError exception = assertThrows(HTTPError.class, () -> reminders.patch(request));
+
+    assertEquals("Reminder was not found", exception.getMessage());
+    assertEquals(404, exception.getStatus());
   }
 }

--- a/src/test/java/com/k3ntako/HTTPServer/controllers/RemindersTest.java
+++ b/src/test/java/com/k3ntako/HTTPServer/controllers/RemindersTest.java
@@ -117,4 +117,33 @@ class RemindersTest {
     assertEquals("Reminder was not found", exception.getMessage());
     assertEquals(404, exception.getStatus());
   }
+
+  @Test
+  void patch() throws IOException, HTTPError {
+    var mockUUID = new UUIDMock();
+
+    var content = "text file content!";
+    var request = new RequestMock(
+        "PATCH",
+        "/reminders/" + mockUUID.getDefaultUUID(),
+        "Hello world"
+    );
+
+    var params = new HashMap<String, String>();
+    params.put("id", mockUUID.getDefaultUUID());
+    request.setParams(params);
+
+    var fileIOMock = new FileIOMock(content);
+
+    var textFile = new TextFile(fileIOMock, mockUUID);
+    var reminders = new Reminders(textFile);
+    var response = reminders.patch(request);
+
+    assertEquals("./data/" + mockUUID.getDefaultUUID() + ".txt", fileIOMock.getLastPatchPath().toString());
+
+    var expectedResponse = "HTTP/1.1 200 OK\r\n" +
+        "Content-Length: 0\r\n\r\n";
+
+    assertEquals(expectedResponse, response.createResponse());
+  }
 }

--- a/src/test/java/com/k3ntako/HTTPServer/controllers/RemindersTest.java
+++ b/src/test/java/com/k3ntako/HTTPServer/controllers/RemindersTest.java
@@ -65,9 +65,9 @@ class RemindersTest {
     var content = "text file content!";
     var request = new RequestMock("GET", "/reminders/" + mockUUID.getDefaultUUID());
 
-    var params = new HashMap<String, String>();
-    params.put("id", mockUUID.getDefaultUUID());
-    request.setParams(params);
+    var routeParams = new HashMap<String, String>();
+    routeParams.put("id", mockUUID.getDefaultUUID());
+    request.setRouteParams(routeParams);
 
     var fileIOMock = new FileIOMock(content);
 
@@ -87,9 +87,9 @@ class RemindersTest {
   void getThrows404IfFileIsNotFound() {
     var request = new RequestMock("GET", "/reminders/not-an-id");
 
-    var params = new HashMap<String, String>();
-    params.put("id", "not-an-id");
-    request.setParams(params);
+    var routeParams = new HashMap<String, String>();
+    routeParams.put("id", "not-an-id");
+    request.setRouteParams(routeParams);
 
     var fileIOMock = new FileIOMock((String) null);
 
@@ -109,9 +109,9 @@ class RemindersTest {
     var content = "text file content!";
     var request = new RequestMock("PATCH", "/reminders/" + mockUUID.getDefaultUUID(), content);
 
-    var params = new HashMap<String, String>();
-    params.put("id", mockUUID.getDefaultUUID());
-    request.setParams(params);
+    var routeParams = new HashMap<String, String>();
+    routeParams.put("id", mockUUID.getDefaultUUID());
+    request.setRouteParams(routeParams);
 
     var fileIOMock = new FileIOMock();
 
@@ -132,9 +132,9 @@ class RemindersTest {
   void patchReturns404IfFileNotFound() {
     var request = new RequestMock("PATCH", "/reminders/not-an-id");
 
-    var params = new HashMap<String, String>();
-    params.put("id", "not-an-id");
-    request.setParams(params);
+    var routeParams = new HashMap<String, String>();
+    routeParams.put("id", "not-an-id");
+    request.setRouteParams(routeParams);
 
     var fileIOMock = new FileIOMock(new IOException("File does not exist"));
 
@@ -153,9 +153,9 @@ class RemindersTest {
     var patchBody = "hello post!\nsecond line";
     var request = new RequestMock("PATCH", "/reminders", patchBody);
 
-    var params = new HashMap<String, String>();
-    params.put("id", mockUUID.getDefaultUUID());
-    request.setParams(params);
+    var routeParams = new HashMap<String, String>();
+    routeParams.put("id", mockUUID.getDefaultUUID());
+    request.setRouteParams(routeParams);
 
     var textFile = new TextFile(new FileIOMock(), mockUUID);
     var reminders = new Reminders(textFile);

--- a/src/test/java/com/k3ntako/HTTPServer/controllers/RemindersTest.java
+++ b/src/test/java/com/k3ntako/HTTPServer/controllers/RemindersTest.java
@@ -121,7 +121,8 @@ class RemindersTest {
 
     assertEquals("./data/" + mockUUID.getDefaultUUID() + ".txt", fileIOMock.getLastPatchPath().toString());
 
-    var expectedResponse = "HTTP/1.1 200 OK\r\n" + "Content-Length: 0\r\n\r\n";
+    var expectedResponse = "HTTP/1.1 204 No Content\r\n" +
+        "Content-Length: 0\r\n\r\n";
 
     assertEquals(expectedResponse, response.createResponse());
   }

--- a/src/test/java/com/k3ntako/HTTPServer/controllers/RemindersTest.java
+++ b/src/test/java/com/k3ntako/HTTPServer/controllers/RemindersTest.java
@@ -107,19 +107,20 @@ class RemindersTest {
     var mockUUID = new UUIDMock();
 
     var content = "text file content!";
-    var request = new RequestMock("PATCH", "/reminders/" + mockUUID.getDefaultUUID(), "Hello world");
+    var request = new RequestMock("PATCH", "/reminders/" + mockUUID.getDefaultUUID(), content);
 
     var params = new HashMap<String, String>();
     params.put("id", mockUUID.getDefaultUUID());
     request.setParams(params);
 
-    var fileIOMock = new FileIOMock(content);
+    var fileIOMock = new FileIOMock();
 
     var textFile = new TextFile(fileIOMock, mockUUID);
     var reminders = new Reminders(textFile);
     var response = reminders.patch(request);
 
     assertEquals("./data/" + mockUUID.getDefaultUUID() + ".txt", fileIOMock.getLastPatchPath().toString());
+    assertEquals(content, fileIOMock.getLastPatch());
 
     var expectedResponse = "HTTP/1.1 204 No Content\r\n" +
         "Content-Length: 0\r\n\r\n";

--- a/src/test/java/com/k3ntako/HTTPServer/controllers/SimpleGetTest.java
+++ b/src/test/java/com/k3ntako/HTTPServer/controllers/SimpleGetTest.java
@@ -18,7 +18,7 @@ class SimpleGetTest {
     var response = simpleGet.get(request);
 
     var responseStr = response.createResponse();
-    var expectedResponse = "HTTP/1.1 200 OK\r\n" +
+    var expectedResponse = "HTTP/1.1 204 No Content\r\n" +
         "Content-Length: 0\r\n\r\n";
     assertEquals(expectedResponse, responseStr);
   }

--- a/src/test/java/com/k3ntako/HTTPServer/mocks/FileIOMock.java
+++ b/src/test/java/com/k3ntako/HTTPServer/mocks/FileIOMock.java
@@ -2,13 +2,13 @@ package com.k3ntako.HTTPServer.mocks;
 
 import com.k3ntako.HTTPServer.FileIOInterface;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
 import java.nio.file.Path;
 
 public class FileIOMock implements FileIOInterface {
   private String lastWrite;
   private Path lastWritePath;
+  private String lastPatch;
+  private Path lastPatchPath;
   private Path lastReadPath;
   private String lastGetResourceFileName;
   private String mockFileContent;
@@ -34,6 +34,12 @@ public class FileIOMock implements FileIOInterface {
   }
 
   @Override
+  public void patchNewLine(Path path, String str) {
+    lastPatchPath = path;
+    lastPatch = str;
+  }
+
+  @Override
   public String getResource(String fileName) {
     lastGetResourceFileName = fileName;
     return mockFileContent;
@@ -45,6 +51,14 @@ public class FileIOMock implements FileIOInterface {
 
   public Path getLastWritePath() {
     return lastWritePath;
+  }
+
+  public String getLastPatch() {
+    return lastPatch;
+  }
+
+  public Path getLastPatchPath() {
+    return lastPatchPath;
   }
 
   public Path getLastReadPath() {

--- a/src/test/java/com/k3ntako/HTTPServer/mocks/FileIOMock.java
+++ b/src/test/java/com/k3ntako/HTTPServer/mocks/FileIOMock.java
@@ -2,6 +2,7 @@ package com.k3ntako.HTTPServer.mocks;
 
 import com.k3ntako.HTTPServer.FileIOInterface;
 
+import java.io.IOException;
 import java.nio.file.Path;
 
 public class FileIOMock implements FileIOInterface {
@@ -12,9 +13,14 @@ public class FileIOMock implements FileIOInterface {
   private Path lastReadPath;
   private String lastGetResourceFileName;
   private String mockFileContent;
+  private IOException mockException;
 
   public FileIOMock() {
-    this.mockFileContent = "Mock file content was not set";
+     this.mockFileContent = "Mock file content was not set";
+  }
+
+  public FileIOMock(IOException exception) {
+    this.mockException = exception;
   }
 
   public FileIOMock(String mockFileContent) {
@@ -22,25 +28,29 @@ public class FileIOMock implements FileIOInterface {
   }
 
   @Override
-  public void write(Path path, String str) {
+  public void write(Path path, String str) throws IOException {
+    throwIfExceptionExists();
     lastWritePath = path;
     lastWrite = str;
   }
 
   @Override
-  public String read(Path path) {
+  public String read(Path path) throws IOException {
+    throwIfExceptionExists();
     lastReadPath = path;
     return mockFileContent;
   }
 
   @Override
-  public void patchNewLine(Path path, String str) {
+  public void patchNewLine(Path path, String str) throws IOException {
+    throwIfExceptionExists();
     lastPatchPath = path;
     lastPatch = str;
   }
 
   @Override
-  public String getResource(String fileName) {
+  public String getResource(String fileName) throws IOException {
+    throwIfExceptionExists();
     lastGetResourceFileName = fileName;
     return mockFileContent;
   }
@@ -67,5 +77,11 @@ public class FileIOMock implements FileIOInterface {
 
   public String getLastGetResourceFileName() {
     return lastGetResourceFileName;
+  }
+
+  private void throwIfExceptionExists() throws IOException {
+    if(mockException != null){
+      throw mockException;
+    }
   }
 }

--- a/src/test/java/com/k3ntako/HTTPServer/mocks/RequestMock.java
+++ b/src/test/java/com/k3ntako/HTTPServer/mocks/RequestMock.java
@@ -56,6 +56,11 @@ public class RequestMock implements RequestInterface {
     return params;
   }
 
+  @Override
+  public String getParam(String key) {
+    return this.params.get(key);
+  }
+
   public String getMethod() {
     return this.method;
   }

--- a/src/test/java/com/k3ntako/HTTPServer/mocks/RequestMock.java
+++ b/src/test/java/com/k3ntako/HTTPServer/mocks/RequestMock.java
@@ -9,7 +9,7 @@ public class RequestMock implements RequestInterface {
   private String route;
   private String protocol = "HTTP/1.1";
   private HashMap<String, String> headers = new HashMap<>();
-  private HashMap<String, String> params;
+  private HashMap<String, String> routeParams;
   private String body = "";
 
   public RequestMock(
@@ -47,18 +47,18 @@ public class RequestMock implements RequestInterface {
   public void parseRequest() {
   }
 
-  public void setParams(HashMap<String, String> params) {
-    this.params = params;
+  public void setRouteParams(HashMap<String, String> routeParams) {
+    this.routeParams = routeParams;
   }
 
   @Override
-  public HashMap<String, String> getParams() {
-    return params;
+  public HashMap<String, String> getRouteParams() {
+    return routeParams;
   }
 
   @Override
-  public String getParam(String key) {
-    return this.params.get(key);
+  public String getRouteParam(String key) {
+    return this.routeParams.get(key);
   }
 
   public String getMethod() {

--- a/src/test/java/com/k3ntako/HTTPServer/mocks/RequestMock.java
+++ b/src/test/java/com/k3ntako/HTTPServer/mocks/RequestMock.java
@@ -7,10 +7,10 @@ import java.util.HashMap;
 public class RequestMock implements RequestInterface {
   private String method;
   private String route;
-  private String protocol;
-  private HashMap<String, String> headers;
+  private String protocol = "HTTP/1.1";
+  private HashMap<String, String> headers = new HashMap<>();
   private HashMap<String, String> params;
-  private String body;
+  private String body = "";
 
   public RequestMock(
       String method,
@@ -18,6 +18,16 @@ public class RequestMock implements RequestInterface {
   ) {
     this.method = method;
     this.route = route;
+  }
+
+  public RequestMock(
+      String method,
+      String route,
+      String body
+  ) {
+    this.method = method;
+    this.route = route;
+    this.body = body;
   }
 
   public RequestMock(


### PR DESCRIPTION
1. Accepts `PATCH` request to `/reminders/:id`
    - Request body must be a single line
2. Content of the request body, if valid, will be appended as a new line to the specified reminder
3. Responds with a `204 No Content` if successful
    - Responds with a `400` if request body is multiline
    - Responds with a `404` if requested file does not exist

Question: I realized that I had been returning a `200` for successful responses with no content. I changed all requests to return `204` instead, which seems to be the expected behavior based on HTTP response norms. Does this make sense, or should I revert it?