### PR TITLE
Fix PublicFiles issue resolving content-type

### DIFF
--- a/src/main/java/com/k3ntako/HTTPServer/RouteRegistrar.java
+++ b/src/main/java/com/k3ntako/HTTPServer/RouteRegistrar.java
@@ -14,19 +14,22 @@ public class RouteRegistrar implements RouteRegistrarInterface {
   final private DataDirectoryIO dataDirectoryIO;
   final private ReminderIOInterface reminderIO;
   final private FileExtensions fileExt;
+  final private MimeTypes mimeTypes;
 
   public RouteRegistrar(
       RouteRegistry routeRegistry,
       FileIOInterface fileIO,
       DataDirectoryIO dataDirectoryIO,
       ReminderIOInterface reminderIO,
-      FileExtensions fileExt
-      ) {
+      FileExtensions fileExt,
+      MimeTypes mimeTypes
+  ) {
     this.routeRegistry = routeRegistry;
     this.fileIO = fileIO;
     this.dataDirectoryIO = dataDirectoryIO;
     this.reminderIO = reminderIO;
     this.fileExt = fileExt;
+    this.mimeTypes = mimeTypes;
   }
 
   @Override
@@ -44,8 +47,8 @@ public class RouteRegistrar implements RouteRegistrarInterface {
     route("DELETE", "/api/images/:image_id", (RequestInterface req, ResponseInterface res) -> new Images(dataDirectoryIO, new UUID(), fileExt).delete(req, res));
 
     route("GET", "/account", (RequestInterface req, ResponseInterface res) -> new Account().get(req, res));
-    route("GET", "/", (RequestInterface req, ResponseInterface res) -> new PublicFiles(fileIO).get(req, res));
-    route("GET", "/*", (RequestInterface req, ResponseInterface res) -> new PublicFiles(fileIO).get(req, res));
+    route("GET", "/", (RequestInterface req, ResponseInterface res) -> new PublicFiles(fileIO, mimeTypes).get(req, res));
+    route("GET", "/*", (RequestInterface req, ResponseInterface res) -> new PublicFiles(fileIO, mimeTypes).get(req, res));
 
     return routeRegistry;
   }

--- a/src/main/java/com/k3ntako/HTTPServer/ServerGenerator.java
+++ b/src/main/java/com/k3ntako/HTTPServer/ServerGenerator.java
@@ -7,6 +7,7 @@ import com.k3ntako.HTTPServer.fileSystemsIO.ReminderIO;
 import com.k3ntako.HTTPServer.fileSystemsIO.YamlIOInterface;
 import com.k3ntako.HTTPServer.utilities.FileExtensions;
 import com.k3ntako.HTTPServer.utilities.JsonConverter;
+import com.k3ntako.HTTPServer.utilities.MimeTypes;
 import com.k3ntako.HTTPServer.utilities.UUID;
 import com.k3ntako.HTTPServer.wrappers.ServerSocketWrapper;
 
@@ -47,7 +48,7 @@ public class ServerGenerator {
 
     var dataDirectoryIO = new DataDirectoryIO(fileIO, dataDir);
     var reminderIO = new ReminderIO(dataDirectoryIO, jsonConverter, new UUID());
-    var routeRegistrar = new RouteRegistrar(new RouteRegistry(), fileIO, dataDirectoryIO, reminderIO, new FileExtensions());
+    var routeRegistrar = new RouteRegistrar(new RouteRegistry(), fileIO, dataDirectoryIO, reminderIO, new FileExtensions(), new MimeTypes());
     var routeRegistry = routeRegistrar.registerRoutes();
     return new Router(routeRegistry);
   }

--- a/src/main/java/com/k3ntako/HTTPServer/controllers/PublicFiles.java
+++ b/src/main/java/com/k3ntako/HTTPServer/controllers/PublicFiles.java
@@ -2,14 +2,17 @@ package com.k3ntako.HTTPServer.controllers;
 
 import com.k3ntako.HTTPServer.*;
 import com.k3ntako.HTTPServer.fileSystemsIO.FileIOInterface;
+import com.k3ntako.HTTPServer.utilities.MimeTypes;
 
 import java.io.IOException;
 
 public class PublicFiles {
   final private FileIOInterface fileIO;
+  final private MimeTypes mimeTypes;
 
-  public PublicFiles(FileIOInterface fileIO) {
+  public PublicFiles(FileIOInterface fileIO, MimeTypes mimeTypes) {
     this.fileIO = fileIO;
+    this.mimeTypes = mimeTypes;
   }
 
   public ResponseInterface get(RequestInterface request, ResponseInterface response) throws HTTPError, IOException {
@@ -20,24 +23,23 @@ public class PublicFiles {
     // Ideally, it would only perform this if the route is a directory,
     // however, Unix directories are files, so there is no simple check.
     byte[] fileBytes = findIndexHTML(fileName);
-    String contentType = null;
+    String contentType;
 
     if (fileBytes != null) {
       contentType = "text/html";
     } else {
       // If directory, returns file names inside.
       fileBytes = fileIO.getResourceIfExists(fileName);
-
-      if (fileBytes != null) {
-        contentType = fileIO.probeResourceContentType(fileName);
-      }
+      contentType = mimeTypes.guessContentType(fileBytes, fileName);
     }
 
     if (fileBytes == null) {
       throw new HTTPError(404, "Not found");
     }
 
-    response.addHeader("Content-Type", contentType);
+    if (contentType != null) {
+      response.addHeader("Content-Type", contentType);
+    }
     response.setBody(fileBytes);
 
     return response;

--- a/src/main/java/com/k3ntako/HTTPServer/fileSystemsIO/FileIO.java
+++ b/src/main/java/com/k3ntako/HTTPServer/fileSystemsIO/FileIO.java
@@ -70,24 +70,6 @@ public class FileIO implements FileIOInterface {
     return scanner.hasNext() ? scanner.next() : "";
   }
 
-  public String probeResourceContentType(String fileName) throws HTTPError {
-    try {
-      var url = this.getClass().getClassLoader().getResource(fileName);
-
-      if (url == null) {
-        throw new HTTPError(404, "Resource not found");
-      }
-
-      Path path = new File(url.toURI()).toPath();
-
-      return Files.probeContentType(path);
-    } catch (IOException e) {
-      throw new HTTPError(404, e.getMessage());
-    } catch (URISyntaxException e) {
-      throw new HTTPError(500, e.getMessage());
-    }
-  }
-
   public void patchNewLine(Path path, String str) throws IOException {
     if (!doesFileExist(path)) {
       throw new IOException("File does not exist");

--- a/src/main/java/com/k3ntako/HTTPServer/fileSystemsIO/FileIOInterface.java
+++ b/src/main/java/com/k3ntako/HTTPServer/fileSystemsIO/FileIOInterface.java
@@ -25,7 +25,5 @@ public interface FileIOInterface {
 
   byte[] getResourceIfExists(String fileName) throws IOException;
 
-  String probeResourceContentType(String fileName) throws HTTPError;
-
   File[] listFiles(Path path);
 }

--- a/src/test/java/com/k3ntako/HTTPServer/RequestHandlerTest.java
+++ b/src/test/java/com/k3ntako/HTTPServer/RequestHandlerTest.java
@@ -3,6 +3,7 @@ package com.k3ntako.HTTPServer;
 import com.k3ntako.HTTPServer.fileSystemsIO.DataDirectoryIO;
 import com.k3ntako.HTTPServer.mocks.*;
 import com.k3ntako.HTTPServer.utilities.FileExtensions;
+import com.k3ntako.HTTPServer.utilities.MimeTypes;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -18,7 +19,8 @@ class RequestHandlerTest {
         fileIO,
         dataDirectoryIO,
         new ReminderIOMock(),
-        new FileExtensions()
+        new FileExtensions(),
+        new MimeTypes()
     );
     var routeRegistry = routeRegistrar.registerRoutes();
 
@@ -45,7 +47,8 @@ class RequestHandlerTest {
         fileIO,
         dataDirectoryIO,
         new ReminderIOMock(),
-        new FileExtensions()
+        new FileExtensions(),
+        new MimeTypes()
     );
     var routeRegistry = routeRegistrar.registerRoutes();
 

--- a/src/test/java/com/k3ntako/HTTPServer/RouteRegistrarTest.java
+++ b/src/test/java/com/k3ntako/HTTPServer/RouteRegistrarTest.java
@@ -5,6 +5,7 @@ import com.k3ntako.HTTPServer.mocks.FileIOMock;
 import com.k3ntako.HTTPServer.mocks.ReminderIOMock;
 import com.k3ntako.HTTPServer.mocks.RequestMock;
 import com.k3ntako.HTTPServer.utilities.FileExtensions;
+import com.k3ntako.HTTPServer.utilities.MimeTypes;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -21,7 +22,8 @@ class RouteRegistrarTest {
         fileIO,
         dataDirectoryIO,
         new ReminderIOMock(),
-        new FileExtensions()
+        new FileExtensions(),
+        new MimeTypes()
     );
     var routeRegistry = routeRegistrar.registerRoutes();
     var request = new RequestMock("GET", "/api/simple_get");
@@ -40,7 +42,8 @@ class RouteRegistrarTest {
         fileIO,
         dataDirectoryIO,
         new ReminderIOMock(),
-        new FileExtensions()
+        new FileExtensions(),
+        new MimeTypes()
     );
     var routeRegistry = routeRegistrar.registerRoutes();
     var request = new RequestMock("GET", "/api/simple_get_with_body");

--- a/src/test/java/com/k3ntako/HTTPServer/RouterTest.java
+++ b/src/test/java/com/k3ntako/HTTPServer/RouterTest.java
@@ -6,6 +6,7 @@ import com.k3ntako.HTTPServer.mocks.ReminderIOMock;
 import com.k3ntako.HTTPServer.mocks.RequestMock;
 import com.k3ntako.HTTPServer.mocks.RouteRegistrarMock;
 import com.k3ntako.HTTPServer.utilities.FileExtensions;
+import com.k3ntako.HTTPServer.utilities.MimeTypes;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
@@ -23,7 +24,8 @@ class RouterTest {
         fileIO,
         dataDirectoryIO,
         new ReminderIOMock(),
-        new FileExtensions()
+        new FileExtensions(),
+        new MimeTypes()
     );
     var routeRegistry = routeRegistrar.registerRoutes();
 
@@ -50,7 +52,8 @@ class RouterTest {
         fileIO,
         dataDirectoryIO,
         new ReminderIOMock(),
-        new FileExtensions()
+        new FileExtensions(),
+        new MimeTypes()
     );
     var routeRegistry = routeRegistrar.registerRoutes();
 

--- a/src/test/java/com/k3ntako/HTTPServer/ServerTest.java
+++ b/src/test/java/com/k3ntako/HTTPServer/ServerTest.java
@@ -3,6 +3,7 @@ package com.k3ntako.HTTPServer;
 import com.k3ntako.HTTPServer.fileSystemsIO.DataDirectoryIO;
 import com.k3ntako.HTTPServer.mocks.*;
 import com.k3ntako.HTTPServer.utilities.FileExtensions;
+import com.k3ntako.HTTPServer.utilities.MimeTypes;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -28,7 +29,8 @@ class ServerTest {
         fileIO,
         dataDirectoryIO,
         new ReminderIOMock(),
-        new FileExtensions()
+        new FileExtensions(),
+        new MimeTypes()
     );
     var routeRegistry = routeRegistrar.registerRoutes();
     var router = new Router(routeRegistry);
@@ -66,7 +68,8 @@ class ServerTest {
         fileIO,
         dataDirectoryIO,
         new ReminderIOMock(),
-        new FileExtensions()
+        new FileExtensions(),
+        new MimeTypes()
     );
     var routeRegistry = routeRegistrar.registerRoutes();
     var router = new Router(routeRegistry);
@@ -109,7 +112,8 @@ class ServerTest {
         fileIO,
         dataDirectoryIO,
         new ReminderIOMock(),
-        new FileExtensions()
+        new FileExtensions(),
+        new MimeTypes()
     );
     var routeRegistry = routeRegistrar.registerRoutes();
     var router = new Router(routeRegistry);

--- a/src/test/java/com/k3ntako/HTTPServer/controllers/PublicFilesTest.java
+++ b/src/test/java/com/k3ntako/HTTPServer/controllers/PublicFilesTest.java
@@ -4,6 +4,7 @@ import com.k3ntako.HTTPServer.HTTPError;
 import com.k3ntako.HTTPServer.mocks.FileIOMock;
 import com.k3ntako.HTTPServer.mocks.RequestMock;
 import com.k3ntako.HTTPServer.mocks.ResponseMock;
+import com.k3ntako.HTTPServer.utilities.MimeTypes;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -17,7 +18,7 @@ class PublicFilesTest {
     final var request = new RequestMock("GET", "/index.html");
 
     final var fileIO = new FileIOMock(new String[]{null, "<html></html>"});
-    final var publicFiles = new PublicFiles(fileIO);
+    final var publicFiles = new PublicFiles(fileIO, new MimeTypes());
     final var response = (ResponseMock) publicFiles.get(request, new ResponseMock());
 
     assertEquals("public/index.html", fileIO.getLastGetResourceIfExistsFileName());
@@ -32,7 +33,7 @@ class PublicFilesTest {
     final var request = new RequestMock("GET", "/");
 
     final var fileIO = new FileIOMock("<html></html>");
-    final var publicFiles = new PublicFiles(fileIO);
+    final var publicFiles = new PublicFiles(fileIO, new MimeTypes());
     final var response = (ResponseMock) publicFiles.get(request, new ResponseMock());
 
     assertEquals("public/index.html", fileIO.getLastGetResourceIfExistsFileName());
@@ -47,7 +48,7 @@ class PublicFilesTest {
 
     var mockReturns = new byte[][]{null, new byte[]{1, 2, 3, 4, 5, 6}};
     final var fileIO = new FileIOMock(mockReturns);
-    final var publicFiles = new PublicFiles(fileIO);
+    final var publicFiles = new PublicFiles(fileIO, new MimeTypes());
     final var response = (ResponseMock) publicFiles.get(request, new ResponseMock());
 
     assertEquals("public/images/dogs/mocha.png", fileIO.getLastGetResourceIfExistsFileName());
@@ -61,7 +62,7 @@ class PublicFilesTest {
     final var request = new RequestMock("GET", "/");
 
     final var fileIO = new FileIOMock(new byte[][]{null, "index.html\nindex.css".getBytes()});
-    final var publicFiles = new PublicFiles(fileIO);
+    final var publicFiles = new PublicFiles(fileIO, new MimeTypes());
     final var response = (ResponseMock) publicFiles.get(request, new ResponseMock());
 
     assertEquals("public/", fileIO.getLastGetResourceIfExistsFileName());
@@ -77,7 +78,7 @@ class PublicFilesTest {
     final var request = new RequestMock("GET", "/index.html");
 
     final var fileIO = new FileIOMock((byte[]) null);
-    final var publicFiles = new PublicFiles(fileIO);
+    final var publicFiles = new PublicFiles(fileIO, new MimeTypes());
 
     HTTPError exception = assertThrows(HTTPError.class, () -> publicFiles.get(request, new ResponseMock()));
 
@@ -90,7 +91,7 @@ class PublicFilesTest {
     final var request = new RequestMock("GET", "/");
 
     final var fileIO = new FileIOMock((byte[]) null);
-    final var publicFiles = new PublicFiles(fileIO);
+    final var publicFiles = new PublicFiles(fileIO, new MimeTypes());
 
     HTTPError exception = assertThrows(HTTPError.class, () -> publicFiles.get(request, new ResponseMock()));
 

--- a/src/test/java/com/k3ntako/HTTPServer/mocks/FileIOMock.java
+++ b/src/test/java/com/k3ntako/HTTPServer/mocks/FileIOMock.java
@@ -146,11 +146,6 @@ public class FileIOMock implements FileIOInterface {
   }
 
   @Override
-  public String probeResourceContentType(String fileName) {
-    return null;
-  }
-
-  @Override
   public File[] listFiles(Path path) {
     lastListFilesPath = path;
 


### PR DESCRIPTION
Issue on ElasticBeanstalk with public files. Accessing any public files, except `index.html` files, returned a 500 error with the message `URI is not hierarchical`. When retrieving the file, I was using a URI to determine the content type. The `resource` directory is a separate directory in the IDE, however, it gets bundled into the JAR file before deployment. Contents in the `resource` directory should not be accessed using a path, url, or uri. 

To resolve the issue, program uses `MimeTypes` to look at the bytes of the file and the file name, instead of using `probeResourceContentType` to directly look at the file.