### PR TITLE
Prevent stderr to be printed to console during tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 
 test {
     useJUnitPlatform()
-    environment "ENV_NAME", "test"
+    environment "ERR_LOGGING", "true"
 }
 
 jar {

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ dependencies {
 
 test {
     useJUnitPlatform()
+    environment "ENV_NAME", "test"
 }
 
 jar {

--- a/src/main/java/com/k3ntako/HTTPServer/ErrorHandler.java
+++ b/src/main/java/com/k3ntako/HTTPServer/ErrorHandler.java
@@ -4,7 +4,22 @@ import com.google.gson.Gson;
 import com.k3ntako.HTTPServer.utilities.MimeTypes;
 import com.k3ntako.HTTPServer.utilities.JsonConverter;
 
+import java.io.OutputStream;
+import java.io.PrintStream;
+
 public class ErrorHandler implements ErrorHandlerInterface {
+  public ErrorHandler() {
+    if(System.getenv().get("ENV_NAME").equals("test")){
+      disableErrLogging();
+    }
+  }
+
+  private void disableErrLogging(){
+    System.setErr(new PrintStream(new OutputStream() {
+      public void write(int b) {} // Ignores standard error
+    }));
+  }
+
   @Override
   public ResponseInterface handleError(HTTPError e) throws HTTPError {
     return generateErrorResponse(e.getStatus(), e);
@@ -16,6 +31,7 @@ public class ErrorHandler implements ErrorHandlerInterface {
   }
 
   private ResponseInterface generateErrorResponse(int status, Exception exception) throws HTTPError {
+    exception.printStackTrace();
     var jsonConverter = new JsonConverter(new Gson());
     var response = new Response(jsonConverter, new MimeTypes());
     response.setStatus(status);

--- a/src/main/java/com/k3ntako/HTTPServer/ErrorHandler.java
+++ b/src/main/java/com/k3ntako/HTTPServer/ErrorHandler.java
@@ -9,7 +9,9 @@ import java.io.PrintStream;
 
 public class ErrorHandler implements ErrorHandlerInterface {
   public ErrorHandler() {
-    if(System.getenv().get("ENV_NAME").equals("test")){
+    var enableErrLogging = System.getenv().get("ERR_LOGGING");
+
+    if(enableErrLogging != null && enableErrLogging.equals("true")){
       disableErrLogging();
     }
   }

--- a/src/test/java/com/k3ntako/HTTPServer/ErrorHandlerTest.java
+++ b/src/test/java/com/k3ntako/HTTPServer/ErrorHandlerTest.java
@@ -8,7 +8,7 @@ class ErrorHandlerTest {
 
   @Test
   void handleHTTPError() throws HTTPError {
-    var httpError = new HTTPError(404, "File was not found");
+    var httpError = new HTTPError(404, "Mock error");
     var errorHandler = new ErrorHandler();
 
     var response = errorHandler.handleError(httpError);
@@ -16,15 +16,15 @@ class ErrorHandlerTest {
 
     var expectedResponse = "HTTP/1.1 404 Not Found\r\n" +
         "Content-Type: text/plain\r\n" +
-        "Content-Length: 18\r\n\r\n" +
-        "File was not found";
+        "Content-Length: 10\r\n\r\n" +
+        "Mock error";
 
     assertEquals(expectedResponse, new String(responseStr));
   }
 
   @Test
   void handleServerError() throws HTTPError {
-    var error = new Exception("Something went wrong");
+    var error = new Exception("Mock error");
     var errorHandler = new ErrorHandler();
 
     var response = errorHandler.handleError(error);
@@ -32,8 +32,8 @@ class ErrorHandlerTest {
 
     var expectedResponse = "HTTP/1.1 500 Internal Server Error\r\n" +
         "Content-Type: text/plain\r\n" +
-        "Content-Length: 20\r\n\r\n" +
-        "Something went wrong";
+        "Content-Length: 10\r\n\r\n" +
+        "Mock error";
 
     assertEquals(expectedResponse, new String(responseStr));
   }


### PR DESCRIPTION
Gradle seems to have ways to turn off logging for tests in the configuration, however, it did not seem to work for me. 
The following did not work, and I did try tinkering around without much success.
```
testLogging.showStandardStreams = false
```

https://docs.gradle.org/current/dsl/org.gradle.api.tasks.testing.Test.html

I eventually set an environment variable, and disabled error logging just for testing.